### PR TITLE
Fix weather api

### DIFF
--- a/specifications/passive/android_phone-1.0.0.yml
+++ b/specifications/passive/android_phone-1.0.0.yml
@@ -150,13 +150,3 @@ data:
     value_schema: .passive.phone.PhoneUserInteraction
     sample_rate:
       dynamic: true
-  # Weather
-  - type: WEATHER
-    app_provider: .weather.WeatherApiProvider
-    unit: NON_DIMENSIONAL
-    processing_state: RAW
-    topic: android_local_weather
-    value_schema: .passive.weather.LocalWeather
-    sample_rate:
-      interval: 10800
-      configurable: true

--- a/specifications/passive/openweathermap_api-0.1.0.yml
+++ b/specifications/passive/openweathermap_api-0.1.0.yml
@@ -1,0 +1,15 @@
+#====================================== Android Phone Sensors =====================================#
+vendor: OPENWEATHERMAP
+model: API
+version: 0.1.0
+data:
+  # Weather
+  - type: WEATHER
+    app_provider: .weather.WeatherApiProvider
+    unit: NON_DIMENSIONAL
+    processing_state: RAW
+    topic: android_local_weather
+    value_schema: .passive.weather.LocalWeather
+    sample_rate:
+      interval: 10800
+      configurable: true


### PR DESCRIPTION
Add specification for the weather API. The weather API provider had a separate vendor/model set. To retroactively enable the weather provider, add a source type `OPENWEATHERMAP`/`API`/`0.1.0` in ManagementPortal.