### PR TITLE
add timeNotification to further schemas.

### DIFF
--- a/commons/active/notification/notification.avsc
+++ b/commons/active/notification/notification.avsc
@@ -2,7 +2,7 @@
   "namespace": "org.radarcns.active.notification",
   "type": "record",
   "name": "Notification",
-  "doc": "General schema for notifications. Check the specification folder to see how the notification has been defined. For each NotificationType there is a JSON file reporting the questions set and possible answers if available.",
+  "doc": "NOTE: THIS SCHEMA IS DEPRACATED. PLEASE USE org.radarcns.active.questionnaire.Questionnaire. General schema for notifications. Check the specification folder to see how the notification has been defined. For each NotificationType there is a JSON file reporting the questions set and possible answers if available.",
   "fields": [
     { "name": "time", "type": "double", "doc": "Timestamp in UTC (s) when the notification is submitted to the subject." },
     { "name": "timeCompleted", "type": "double", "doc": "Timestamp in UTC (s) when subject marks the notification as complete." },

--- a/commons/active/opensmile/open_smile_2_audio_analysis.avsc
+++ b/commons/active/opensmile/open_smile_2_audio_analysis.avsc
@@ -6,6 +6,7 @@
   "fields": [
     {"name": "time", "type": "double", "doc": "Device timestamp in UTC (s)."},
     { "name": "timeCompleted", "type": "double", "doc": "Timestamp in UTC (s) when subject completed the audio questionnaire." },
+    { "name": "timeNotification", "type": ["null", "double"], "doc": "Timestamp in UTC (s) when the notification to complete the questionnaire is sent.", "default": null },
     {"name": "config", "type": "string", "doc": "Contents of an OpenSMILE configuration file." },
     {"name": "data", "type": ["null", "string"], "doc": "Audio features computed by openSMILE in plain text.", "default": null},
     { "name": "reciteText", "type": ["null", "string"], "doc": "Text that was supposed to be recited as part of the recording.", "default": null }

--- a/commons/active/opensmile/open_smile_2_audio_recording.avsc
+++ b/commons/active/opensmile/open_smile_2_audio_recording.avsc
@@ -6,6 +6,7 @@
   "fields": [
     { "name": "time", "type": "double", "doc": "Device timestamp when the audio recording was started (s since the Unix Epoch)." },
     { "name": "timeCompleted", "type": "double", "doc": "Device timestamp when the audio recording was completed (s since the Unix Epoch)." },
+    { "name": "timeNotification", "type": ["null", "double"], "doc": "Timestamp in UTC (s) when the notification to complete the questionnaire is sent.", "default": null },
     { "name": "mediaType", "type": "string", "doc": "Media type of the audio recording format. For example, audio/wav for a WAV recording. See https://www.iana.org/assignments/media-types/media-types.xhtml#audio for the list of standardized audio media types."},
     { "name": "data", "type": "string", "doc": "Base64 encoded contents of the recorded audio file." },
     { "name": "reciteText", "type": ["null", "string"], "doc": "Text that was supposed to be recited as part of the recording.", "default": null }

--- a/specifications/active/aRMT-1.4.2.yml
+++ b/specifications/active/aRMT-1.4.2.yml
@@ -1,0 +1,57 @@
+name: aRMT
+vendor: RADAR
+model: aRMT-App
+version: 1.4.1
+assessment_type: QUESTIONNAIRE
+doc: aRMT Questionnaires definition. Includes Personal Health Questionnaire Depression Scale (PHQ-8), Experience sampling method (ESM) and RSES and other data.
+data:
+  - type: THINC-IT
+    topic: notification_thinc_it
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/blob/master/questionnaires/thinc_it/thinc_it_armt.json
+  - type: ROMBERG_TEST
+    doc: The value of the task is in milliseconds (ms).
+    topic: task_romberg_test
+    value_schema: .active.task.Task
+    questionnaire_definition_url: https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/blob/master/questionnaires/romberg_test/romberg_test_armt.json
+  - type: 2MW_TEST
+    doc: The value of the task is in milliseconds (ms).
+    topic: task_2MW_test
+    value_schema: .active.task.Task
+    questionnaire_definition_url: https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/blob/master/questionnaires/2MW_test/2MW_test_armt.json
+  - type: TANDEM_WALKING_TEST
+    doc: The value of the task is in milliseconds (ms).
+    topic: task_tandem_walking_test
+    value_schema: .active.task.Task
+    questionnaire_definition_url: https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/blob/master/questionnaires/tandem_walking_test/tandem_walking_test_armt.json
+  - type: PHQ8
+    topic: questionnaire_phq8
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/phq8/phq8_armt.json
+  - type: ESM
+    topic: questionnaire_esm
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/esm/esm_armt.json
+  - type: AUDIO
+    topic: questionnaire_audio
+    value_schema: .active.opensmile.OpenSmile2AudioRecording
+  - type: RSES
+    topic: questionnaire_rses
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/rses/rses_armt.json
+  - type: PDQ
+    topic: questionnaire_perceived_deficits_questionnaire
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/perceived_deficits_questionnaire/perceived_deficits_questionnaire_armt.json
+  - type: PDDS
+    topic: questionnaire_patient_determined_disease_step
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/patient_determined_disease_step/patient_determined_disease_step_armt.json
+  - type: COMPLETION_LOG
+    doc: Information about the completeness of each questionnaire.
+    topic: questionnaire_completion_log
+    value_schema: .monitor.questionnaire.QuestionnaireCompletionLog
+  - type: TIMEZONE
+    doc: Timezone information sent along with each questionnaire.
+    topic: questionnaire_timezone
+    value_schema: .monitor.application.ApplicationTimeZone


### PR DESCRIPTION
- The notification schema was exactly same as questionnaire schema. So deprecate it and use the questionnaire schema instead. This also means the `timeNotification` is now added for `notification_thinc_it` topic.
- Added `timeNotification` to audio schemas.