### PR TITLE
Empatica spec

### DIFF
--- a/specifications/passive/empatica_e4-1.0.1.yml
+++ b/specifications/passive/empatica_e4-1.0.1.yml
@@ -1,0 +1,55 @@
+#====================================== Empatica E4 Wristband =====================================#
+vendor: EMPATICA
+model: E4
+version: 1.0.1
+app_provider: .empatica.E4ServiceProvider
+data:
+  - type: ACCELEROMETER
+    sample_rate:
+      frequency: 32
+    unit: G
+    processing_state: RAW
+    topic: android_empatica_e4_acceleration
+    value_schema: .passive.empatica.EmpaticaE4Acceleration
+  - type: BATTERY
+    sample_rate:
+      dynamic: true
+    unit: PERCENTAGE
+    processing_state: RAW
+    topic: android_empatica_e4_battery_level
+    value_schema: .passive.empatica.EmpaticaE4BatteryLevel
+  - type: BLOOD_VOLUME_PULSE
+    sample_rate:
+      frequency: 32
+    unit: NANO_WATT
+    processing_state: RAW
+    topic: android_empatica_e4_blood_volume_pulse
+    value_schema: .passive.empatica.EmpaticaE4BloodVolumePulse
+  - type: ELECTRODERMAL_ACTIVITY
+    sample_rate:
+      frequency: 4
+    unit: MICRO_SIEMENS
+    processing_state: RAW
+    topic: android_empatica_e4_electrodermal_activity
+    value_schema: .passive.empatica.EmpaticaE4ElectroDermalActivity
+  - type: INTER_BEAT_INTERVAL
+    sample_rate:
+      dynamic: true
+    unit: BEATS_PER_MIN
+    processing_state: VENDOR
+    topic: android_empatica_e4_inter_beat_interval
+    value_schema: .passive.empatica.EmpaticaE4InterBeatInterval
+  - type: THERMOMETER
+    sample_rate:
+      frequency: 4
+    unit: CELSIUS
+    processing_state: RAW
+    topic: android_empatica_e4_temperature
+    value_schema: .passive.empatica.EmpaticaE4Temperature
+  - type: SENSOR_STATUS
+    sample_rate:
+      dynamic: true
+    unit: NON_DIMENSIONAL
+    processing_state: VENDOR
+    topic: android_empatica_e4_sensor_status
+    value_schema: .passive.empatica.EmpaticaE4SensorStatus

--- a/specifications/passive/empatica_e4-1.1.0.yml
+++ b/specifications/passive/empatica_e4-1.1.0.yml
@@ -1,7 +1,7 @@
 #====================================== Empatica E4 Wristband =====================================#
 vendor: EMPATICA
 model: E4
-version: 1.0.1
+version: 1.1.0
 app_provider: .empatica.E4ServiceProvider
 data:
   - type: ACCELEROMETER


### PR DESCRIPTION
Added the sensor_status topic to the empatica specification, without it the topic is not created by the radar-schemas-tools and the pRMT app won't send the data (throws unblocking exception).

I put it into a new patch version, wasn't sure if that is OK or if it should just be added to v1.0.0.