### PR TITLE
Prevent application status int overflow

### DIFF
--- a/commons/monitor/application/application_record_counts.avsc
+++ b/commons/monitor/application/application_record_counts.avsc
@@ -5,8 +5,8 @@
   "doc": "Number of records cached or created.",
   "fields": [
     { "name": "time", "type": "double", "doc": "Device timestamp in UTC (s)." },
-    { "name": "recordsCached", "type": ["null", "int"], "doc": "Number of records currently being cached.", "default": null },
-    { "name": "recordsSent", "type": "int", "doc": "Number of records sent since application start." },
+    { "name": "recordsCached", "type": ["null", "long"], "doc": "Number of records currently being cached.", "default": null },
+    { "name": "recordsSent", "type": "long", "doc": "Number of records sent since application start." },
     { "name": "recordsUnsent", "type": ["null", "int"], "doc": "Number of unsent records.", "default": null }
   ]
 }


### PR DESCRIPTION
The number of records cached is a bit theoretical (but not entirely out of reach), because it would require about 200 GB of storage. However, at 1000 Hz, recordsSent will exceed integer maximum value after 24 days, which is quite possible.