### PR TITLE
Add additional audio types

### DIFF
--- a/specifications/active/aRMT-1.4.3.yml
+++ b/specifications/active/aRMT-1.4.3.yml
@@ -1,0 +1,63 @@
+name: aRMT
+vendor: RADAR
+model: aRMT-App
+version: 1.4.2
+assessment_type: QUESTIONNAIRE
+doc: aRMT Questionnaires definition. Includes Personal Health Questionnaire Depression Scale (PHQ-8), Experience sampling method (ESM) and RSES and other data.
+data:
+  - type: THINC_IT
+    topic: notification_thinc_it
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/blob/master/questionnaires/thinc_it/thinc_it_armt.json
+  - type: ROMBERG_TEST
+    doc: The value of the task is in milliseconds (ms).
+    topic: task_romberg_test
+    value_schema: .active.task.Task
+    questionnaire_definition_url: https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/blob/master/questionnaires/romberg_test/romberg_test_armt.json
+  - type: 2MW_TEST
+    doc: The value of the task is in milliseconds (ms).
+    topic: task_2MW_test
+    value_schema: .active.task.Task
+    questionnaire_definition_url: https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/blob/master/questionnaires/2MW_test/2MW_test_armt.json
+  - type: TANDEM_WALKING_TEST
+    doc: The value of the task is in milliseconds (ms).
+    topic: task_tandem_walking_test
+    value_schema: .active.task.Task
+    questionnaire_definition_url: https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/blob/master/questionnaires/tandem_walking_test/tandem_walking_test_armt.json
+  - type: PHQ8
+    topic: questionnaire_phq8
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/phq8/phq8_armt.json
+  - type: ESM
+    topic: questionnaire_esm
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/esm/esm_armt.json
+  - type: AUDIO
+    topic: questionnaire_audio
+    value_schema: .active.opensmile.OpenSmile2AudioRecording
+  - type: AUDIO_2
+    topic: questionnaire_audio
+    value_schema: .active.opensmile.OpenSmile2AudioRecording
+  - type: AUDIO_3
+    topic: questionnaire_audio
+    value_schema: .active.opensmile.OpenSmile2AudioRecording
+  - type: RSES
+    topic: questionnaire_rses
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/rses/rses_armt.json
+  - type: PERCEIVED_DEFICITS_QUESTIONNAIRE
+    topic: questionnaire_perceived_deficits_questionnaire
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/perceived_deficits_questionnaire/perceived_deficits_questionnaire_armt.json
+  - type: PATIENT_DETERMINED_DISEASE_STEP
+    topic: questionnaire_patient_determined_disease_step
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/patient_determined_disease_step/patient_determined_disease_step_armt.json
+  - type: COMPLETION_LOG
+    doc: Information about the completeness of each questionnaire.
+    topic: questionnaire_completion_log
+    value_schema: .monitor.questionnaire.QuestionnaireCompletionLog
+  - type: TIMEZONE
+    doc: Timezone information sent along with each questionnaire.
+    topic: questionnaire_timezone
+    value_schema: .monitor.application.ApplicationTimeZone

--- a/specifications/active/aRMT-1.4.3.yml
+++ b/specifications/active/aRMT-1.4.3.yml
@@ -34,13 +34,13 @@ data:
     questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/esm/esm_armt.json
   - type: AUDIO
     topic: questionnaire_audio
-    value_schema: .active.opensmile.OpenSmile2AudioRecording
+    value_schema: .active.questionnaire.Questionnaire
   - type: AUDIO_2
     topic: questionnaire_audio
-    value_schema: .active.opensmile.OpenSmile2AudioRecording
+    value_schema: .active.questionnaire.Questionnaire
   - type: AUDIO_3
     topic: questionnaire_audio
-    value_schema: .active.opensmile.OpenSmile2AudioRecording
+    value_schema: .active.questionnaire.Questionnaire
   - type: RSES
     topic: questionnaire_rses
     value_schema: .active.questionnaire.Questionnaire

--- a/specifications/active/aRMT-1.4.3.yml
+++ b/specifications/active/aRMT-1.4.3.yml
@@ -1,7 +1,7 @@
 name: aRMT
 vendor: RADAR
 model: aRMT-App
-version: 1.4.2
+version: 1.4.3
 assessment_type: QUESTIONNAIRE
 doc: aRMT Questionnaires definition. Includes Personal Health Questionnaire Depression Scale (PHQ-8), Experience sampling method (ESM) and RSES and other data.
 data:


### PR DESCRIPTION
- Add 2 more audio questionnaire types with the same schema and topic
- Rename PDDS to `patient_determined_disease_step`, PDQ to `perceived_deficits_questionnaire`, and THINC-IT to `THINC_IT` to match protocol questionnaire name and aRMT Definitions folders
- Update audio type to use questionnaire schema