### PR TITLE
Deprecated Audio schemas

### DIFF
--- a/commons/active/opensmile/open_smile_2_audio_analysis.avsc
+++ b/commons/active/opensmile/open_smile_2_audio_analysis.avsc
@@ -2,7 +2,7 @@
   "namespace": "org.radarcns.active.opensmile",
   "type": "record",
   "name": "OpenSmile2AudioAnalysis",
-  "doc": "Audio data collected by aRMT app and processed using openSMILE.",
+  "doc": "NOTE: THIS SCHEMA IS DEPRACATED. PLEASE USE org.radarcns.active.questionnaire.Questionnaire. Audio data collected by aRMT app and processed using openSMILE.",
   "fields": [
     {"name": "time", "type": "double", "doc": "Device timestamp in UTC (s)."},
     { "name": "timeCompleted", "type": "double", "doc": "Timestamp in UTC (s) when subject completed the audio questionnaire." },

--- a/commons/active/opensmile/open_smile_2_audio_recording.avsc
+++ b/commons/active/opensmile/open_smile_2_audio_recording.avsc
@@ -2,7 +2,7 @@
   "namespace": "org.radarcns.active.opensmile",
   "name": "OpenSmile2AudioRecording",
   "type": "record",
-  "doc": "Audio recording part of the RADAR aRMT app.",
+  "doc": "NOTE: THIS SCHEMA IS DEPRACATED. PLEASE USE org.radarcns.active.questionnaire.Questionnaire. Audio recording part of the RADAR aRMT app.",
   "fields": [
     { "name": "time", "type": "double", "doc": "Device timestamp when the audio recording was started (s since the Unix Epoch)." },
     { "name": "timeCompleted", "type": "double", "doc": "Device timestamp when the audio recording was completed (s since the Unix Epoch)." },


### PR DESCRIPTION
Deprecated the Active Audio Schemas because -

1. The active app is not using OpenSmile anymore.
2. The active app is using the generic questionnaire schema for publishing audio records.