### PR TITLE
Option to register topics and schemas to confluent cloud env

### DIFF
--- a/Dockerfile.kafkaInit
+++ b/Dockerfile.kafkaInit
@@ -27,6 +27,7 @@ ENV KAFKA_NUM_PARTITIONS=3
 ENV KAFKA_NUM_REPLICATION=3
 ENV KAFKA_NUM_BROKERS=3
 ENV KAFKA_ZOOKEEPER_CONNECT=zookeeper-1:2181
+ENV CC_CONFIG_FILE_PATH=/etc/confluent/java-config.properties
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		curl \
@@ -47,6 +48,7 @@ COPY --from=builder /code/java-sdk/radar-schemas-tools/build/distributions/radar
 COPY --from=builder /code ./original
 
 VOLUME /schema/conf
+VOLUME /etc/confluent/
 # Copy bash file
 COPY ./docker/topic_init.sh ./docker/init.sh ./docker/list_aggregated.sh ./docker/list_raw.sh /usr/bin/
 RUN chmod +x /usr/bin/*.sh

--- a/Dockerfile.kafkaInit
+++ b/Dockerfile.kafkaInit
@@ -50,7 +50,7 @@ COPY --from=builder /code ./original
 VOLUME /schema/conf
 VOLUME /etc/confluent/
 # Copy bash file
-COPY ./docker/topic_init.sh ./docker/init.sh ./docker/list_aggregated.sh ./docker/list_raw.sh /usr/bin/
+COPY ./docker/topic_init.sh ./docker/init.sh ./docker/cc_topic_init.sh ./docker/list_aggregated.sh ./docker/list_raw.sh /usr/bin/
 RUN chmod +x /usr/bin/*.sh
 
 ENTRYPOINT ["init.sh"]

--- a/README.md
+++ b/README.md
@@ -89,6 +89,6 @@ docker-compose run --rm tools radar-schemas-tools cc-topic-create -c path-to-jav
 2. Register schemas on Confluent Cloud schema registry
 
 ```
-docker-compose run --rm tools radar-schemas-tools SR_ENDPOINT -u SR_API_KEY -p SR_API_SECRET
+docker-compose run --rm tools radar-schemas-tools register SR_ENDPOINT -u SR_API_KEY -p SR_API_SECRET
 
 ```

--- a/README.md
+++ b/README.md
@@ -64,3 +64,31 @@ docker-compose run --rm tools radar-schemas-tools schema-topic --backup -f schem
 # ensure the validity of the _schemas topic
 docker-compose run --rm tools radar-schemas-tools schema-topic --ensure -f schema.json -b 1 -r 1 zookeeper-1:2181
 ```
+#### Using radar-schema-tools with Confluent Cloud
+1. Create topics on Confluent Cloud 
+1.1. Create a `java-config.properties` file. A Confluent Cloud config for Java application based on this [template](https://github.com/confluentinc/configuration-templates/blob/master/clients/cloud/java-sr.config).
+```properties
+
+# Kafka
+bootstrap.servers={{ BROKER_ENDPOINT }}
+security.protocol=SASL_SSL
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
+ssl.endpoint.identification.algorithm=https
+sasl.mechanism=PLAIN
+
+# Confluent Cloud Schema Registry
+schema.registry.url=https://{{ SR_ENDPOINT }}
+basic.auth.credentials.source=USER_INFO
+schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
+```
+1.2 Run `cc-topic-create` command
+```
+docker-compose run --rm tools radar-schemas-tools cc-topic-create -c path-to-java-config.properties
+
+```
+2. Register schemas on Confluent Cloud schema registry
+
+```
+docker-compose run --rm tools radar-schemas-tools SR_ENDPOINT -u SR_API_KEY -p SR_API_SECRET
+
+```

--- a/docker/cc_topic_init.sh
+++ b/docker/cc_topic_init.sh
@@ -17,25 +17,6 @@ fi
 
 echo "Registering RADAR-base schemas..."
 
-#tries=10
-#timeout=1
-#max_timeout=32
-#while true; do
-#  if curl -Ifs "${KAFKA_SCHEMA_REGISTRY}" > /dev/null; then
-#    break;
-#  fi
-#  tries=$((tries - 1))
-#  if [ $tries = 0 ]; then
-#    echo "FAILED TO REACH SCHEMA REGISTRY. SCHEMAS NOT REGISTERED"
-#    exit 1
-#  fi
-#  echo "Failed to reach schema registry. Retrying in ${timeout} seconds."
-#  sleep $timeout
-#  if [ $timeout -lt $max_timeout ]; then
-#    timeout=$((timeout * 2))
-#  fi
-#done
-
 if ! radar-schemas-tools register --force -u $CC_API_KEY -p $CC_API_SECRET "${KAFKA_SCHEMA_REGISTRY}" merged; then
   echo "FAILED TO REGISTER SCHEMAS"
   exit 1

--- a/docker/cc_topic_init.sh
+++ b/docker/cc_topic_init.sh
@@ -17,26 +17,26 @@ fi
 
 echo "Registering RADAR-base schemas..."
 
-tries=10
-timeout=1
-max_timeout=32
-while true; do
-  if curl -Ifs "${KAFKA_SCHEMA_REGISTRY}" > /dev/null; then
-    break;
-  fi
-  tries=$((tries - 1))
-  if [ $tries = 0 ]; then
-    echo "FAILED TO REACH SCHEMA REGISTRY. SCHEMAS NOT REGISTERED"
-    exit 1
-  fi
-  echo "Failed to reach schema registry. Retrying in ${timeout} seconds."
-  sleep $timeout
-  if [ $timeout -lt $max_timeout ]; then
-    timeout=$((timeout * 2))
-  fi
-done
+#tries=10
+#timeout=1
+#max_timeout=32
+#while true; do
+#  if curl -Ifs "${KAFKA_SCHEMA_REGISTRY}" > /dev/null; then
+#    break;
+#  fi
+#  tries=$((tries - 1))
+#  if [ $tries = 0 ]; then
+#    echo "FAILED TO REACH SCHEMA REGISTRY. SCHEMAS NOT REGISTERED"
+#    exit 1
+#  fi
+#  echo "Failed to reach schema registry. Retrying in ${timeout} seconds."
+#  sleep $timeout
+#  if [ $timeout -lt $max_timeout ]; then
+#    timeout=$((timeout * 2))
+#  fi
+#done
 
-if ! radar-schemas-tools register --force "${KAFKA_SCHEMA_REGISTRY}" merged; then
+if ! radar-schemas-tools register --force -u $CC_API_KEY -p $CC_API_SECRET "${KAFKA_SCHEMA_REGISTRY}" merged; then
   echo "FAILED TO REGISTER SCHEMAS"
   exit 1
 fi

--- a/java-sdk/radar-schemas-tools/build.gradle
+++ b/java-sdk/radar-schemas-tools/build.gradle
@@ -39,7 +39,7 @@ ext {
     confluentVersion = '5.5.0'
     kafkaVersion = '2.5.0'
     okHttpVersion = '4.7.2'
-    radarCommonsVersion = '0.12.3'
+    radarCommonsVersion = '0.13.0'
     slf4jVersion = '1.7.30'
     javaxValidationVersion = '2.0.1.Final'
 }

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/CommandLineApp.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/CommandLineApp.java
@@ -65,6 +65,7 @@ public class CommandLineApp {
     public CommandLineApp(Path root) throws IOException {
         this.root = root;
         this.catalogue = SourceCatalogue.load(root);
+        logger.info("radar-schema-tools is initialized with root directory {}", this.root);
     }
 
     /**

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/CommandLineApp.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/CommandLineApp.java
@@ -31,6 +31,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparsers;
+import org.radarcns.schema.registration.ConfluentCloudTopics;
 import org.radarcns.schema.registration.KafkaTopics;
 import org.radarcns.schema.registration.SchemaTopicManager;
 import org.radarcns.schema.registration.SchemaRegistry;
@@ -134,6 +135,7 @@ public class CommandLineApp {
     public static void main(String... args) {
         SortedMap<String, SubCommand> subCommands = commandsToMap(
                 KafkaTopics.command(),
+                ConfluentCloudTopics.command(),
                 SchemaRegistry.command(),
                 listCommand(),
                 SchemaValidator.command(),

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/AbstractTopicRegistrar.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/AbstractTopicRegistrar.java
@@ -25,14 +25,6 @@ public abstract class AbstractTopicRegistrar implements TopicRegistrar {
     private static final Logger logger = LoggerFactory.getLogger(AbstractTopicRegistrar.class);
     private Set<String> topics;
 
-    /**
-     * Create all topics in a catalogue based on pattern provided.
-     *
-     * @param catalogue   source catalogue to extract topic names from.
-     * @param partitions  number of partitions per topic.
-     * @param replication number of replicas for a topic.
-     * @return 0 if execution was successful. 1 otherwise.
-     */
     @Override
     public int createTopics(@NotNull SourceCatalogue catalogue, int partitions, short replication,
             String topic, String match) {
@@ -70,14 +62,7 @@ public abstract class AbstractTopicRegistrar implements TopicRegistrar {
         return createTopics(catalogue.getTopicNames(), partitions, replication);
     }
 
-    /**
-     * Create a single topic.
-     *
-     * @param topics      names of the topic to create.
-     * @param partitions  number of partitions per topic.
-     * @param replication number of replicas for a topic.
-     * @return whether the topic was registered.
-     */
+
     @Override
     public boolean createTopics(Stream<String> topics, int partitions, short replication) {
         ensureInitialized();
@@ -105,12 +90,6 @@ public abstract class AbstractTopicRegistrar implements TopicRegistrar {
         }
     }
 
-    /**
-     * Refresh the list of topics from Kafka.
-     *
-     * @return {@code true} if the update succeeded, {@code false} otherwise.
-     * @throws InterruptedException if the request was interrupted.
-     */
     @Override
     public boolean refreshTopics() throws InterruptedException {
         ensureInitialized();
@@ -165,6 +144,11 @@ public abstract class AbstractTopicRegistrar implements TopicRegistrar {
         }
     }
 
+    /**
+     * Returns an instance of {@code AdminClient} for use.
+     *
+     * @return instance of AdminClient.
+     */
     abstract AdminClient getKafkaClient();
 
 }

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/AbstractTopicRegistrar.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/AbstractTopicRegistrar.java
@@ -1,0 +1,170 @@
+package org.radarcns.schema.registration;
+
+import static org.radarcns.schema.CommandLineApp.matchTopic;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.validation.constraints.NotNull;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListTopicsOptions;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.radarcns.schema.specification.SourceCatalogue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractTopicRegistrar implements TopicRegistrar {
+    static final int MAX_SLEEP = 32;
+    private static final Logger logger = LoggerFactory.getLogger(AbstractTopicRegistrar.class);
+    private Set<String> topics;
+
+    /**
+     * Create all topics in a catalogue based on pattern provided.
+     *
+     * @param catalogue   source catalogue to extract topic names from.
+     * @param partitions  number of partitions per topic.
+     * @param replication number of replicas for a topic.
+     * @return 0 if execution was successful. 1 otherwise.
+     */
+    @Override
+    public int createTopics(@NotNull SourceCatalogue catalogue, int partitions, short replication,
+            String topic, String match) {
+        Pattern pattern = matchTopic(topic, match);
+
+        if (pattern == null) {
+            return createTopics(catalogue, partitions, replication) ? 0 : 1;
+        } else {
+            List<String> topicNames =
+                    catalogue.getTopicNames().filter(s -> pattern.matcher(s).find())
+                            .collect(Collectors.toList());
+
+            if (topicNames.isEmpty()) {
+                logger.error("Topic {} does not match a known topic."
+                        + " Find the list of acceptable topics"
+                        + " with the `radar-schemas-tools list` command. Aborting.", pattern);
+                return 1;
+            }
+            return createTopics(topicNames.stream(), partitions, replication) ? 0 : 1;
+        }
+    }
+
+
+    /**
+     * Create all topics in a catalogue.
+     *
+     * @param catalogue   source catalogue to extract topic names from
+     * @param partitions  number of partitions per topic
+     * @param replication number of replicas for a topic
+     * @return whether the whole catalogue was registered
+     */
+    private boolean createTopics(@NotNull SourceCatalogue catalogue, int partitions,
+            short replication) {
+        ensureInitialized();
+        return createTopics(catalogue.getTopicNames(), partitions, replication);
+    }
+
+    /**
+     * Create a single topic.
+     *
+     * @param topics      names of the topic to create.
+     * @param partitions  number of partitions per topic.
+     * @param replication number of replicas for a topic.
+     * @return whether the topic was registered.
+     */
+    @Override
+    public boolean createTopics(Stream<String> topics, int partitions, short replication) {
+        ensureInitialized();
+        try {
+            logger.info("Creating topics. Topics marked with [*] already exist.");
+
+            List<NewTopic> newTopics = topics.sorted().distinct().filter(t -> {
+                if (this.topics.contains(t)) {
+                    logger.info("[*] {}", t);
+                    return false;
+                } else {
+                    logger.info("[ ] {}", t);
+                    return true;
+                }
+            }).map(t -> new NewTopic(t, partitions, replication)).collect(Collectors.toList());
+
+            if (!newTopics.isEmpty()) {
+                getKafkaClient().createTopics(newTopics).all().get();
+                refreshTopics();
+            }
+            return true;
+        } catch (Exception ex) {
+            logger.error("Failed to create topics {}", ex.toString());
+            return false;
+        }
+    }
+
+    /**
+     * Refresh the list of topics from Kafka.
+     *
+     * @return {@code true} if the update succeeded, {@code false} otherwise.
+     * @throws InterruptedException if the request was interrupted.
+     */
+    @Override
+    public boolean refreshTopics() throws InterruptedException {
+        ensureInitialized();
+        logger.info("Waiting for topics to become available.");
+        int sleep = 10;
+        int numTries = 10;
+
+        topics = null;
+        ListTopicsOptions opts = new ListTopicsOptions().listInternal(true);
+        for (int tries = 0; tries < numTries; tries++) {
+            try {
+                topics = getKafkaClient().listTopics(opts).names().get(sleep, TimeUnit.SECONDS);
+            } catch (ExecutionException e) {
+                logger.error("Failed to list topics from brokers: {}."
+                        + " Trying again after {} seconds.", e.toString(), sleep);
+                Thread.sleep(sleep * 1000L);
+                sleep = Math.min(MAX_SLEEP, sleep * 2);
+                continue;
+            } catch (TimeoutException e) {
+                // do nothing
+            }
+            if (topics != null && !topics.isEmpty()) {
+                break;
+            }
+            if (tries < numTries - 1) {
+                logger.warn("Topics not listed yet after {} seconds", sleep);
+            } else {
+                logger.error("Topics have not become available. Failed to wait on Kafka.");
+            }
+            sleep = Math.min(MAX_SLEEP, sleep * 2);
+        }
+
+        if (topics == null || topics.isEmpty()) {
+            return false;
+        } else {
+            Thread.sleep(5000L);
+            return true;
+        }
+    }
+
+    @Override
+    public Set<String> getTopics() {
+        ensureInitialized();
+        return Collections.unmodifiableSet(topics);
+    }
+
+
+    @Override
+    public void close() {
+        if (getKafkaClient() != null) {
+            getKafkaClient().close();
+        }
+    }
+
+    abstract AdminClient getKafkaClient();
+
+}

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/ConfluentCloudTopics.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/ConfluentCloudTopics.java
@@ -1,0 +1,117 @@
+package org.radarcns.schema.registration;
+
+import static org.radarbase.util.Strings.isNullOrEmpty;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Properties;
+import javax.validation.constraints.NotNull;
+
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.radarcns.schema.CommandLineApp;
+import org.radarcns.schema.util.SubCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConfluentCloudTopics extends AbstractTopicRegistrar {
+    private static final Logger logger = LoggerFactory.getLogger(ConfluentCloudTopics.class);
+
+    private AdminClient kafkaClient;
+
+    /**
+     * Create Kafka topics registration object with given Confluent Cloud bootstrap server
+     * configurations.
+     *
+     * @param cloudConfig Confluent cloud config file loaded from configurations.
+     */
+    public ConfluentCloudTopics(@NotNull Properties cloudConfig) {
+        logger.info("Creating Kafka client with bootstrap servers {}", cloudConfig);
+        this.kafkaClient = AdminClient.create(cloudConfig);
+    }
+
+    @Override
+    AdminClient getKafkaClient() {
+        ensureInitialized();
+        return kafkaClient;
+    }
+
+    public void ensureInitialized() {
+        if (this.kafkaClient != null) {
+            throw new IllegalStateException("Kafka client is not initialized yet");
+        }
+    }
+
+    /**
+     * Create a ConfluentCloudTopics command to register topics from the command line.
+     */
+    public static SubCommand command() {
+        return new ConfluentCloudTopicsCommand();
+    }
+
+
+    private static class ConfluentCloudTopicsCommand implements SubCommand {
+        @Override
+        public String getName() {
+            return "cc-topic-create";
+        }
+
+        @Override
+        public int execute(Namespace options, CommandLineApp app) {
+            String configPath = options.getString("config-path");
+            short replication = options.getShort("replication");
+            int partitions = options.getInt("partitions");
+
+            if (isNullOrEmpty(configPath)) {
+                throw new IllegalArgumentException(
+                    "--config-path not found. Confluent " + "cloud config path cannot be empty");
+            }
+
+            try {
+                Properties config = loadConfig(configPath);
+                ConfluentCloudTopics topics = new ConfluentCloudTopics(config);
+
+                return topics.createTopics(app.getCatalogue(), partitions, replication,
+                    options.getString("topic"), options.getString("match"));
+
+            } catch (IOException e) {
+                e.printStackTrace();
+                return 1;
+            }
+        }
+
+        @Override
+        public void addParser(ArgumentParser parser) {
+            parser.description("Create all topics that are missing on the Confluent Cloud env.");
+            parser.addArgument("-c", "--config-path").help("File path for Confluent cloud config")
+                .type(String.class);
+            parser.addArgument("-p", "--partitions").help("number of partitions per topic")
+                .type(Integer.class).setDefault(3);
+            parser.addArgument("-r", "--replication").help("number of replicas per data packet")
+                .type(Short.class).setDefault((short) 3);
+            parser.addArgument("-t", "--topic").help("register the schemas of one topic")
+                .type(String.class);
+            parser.addArgument("-m", "--match").help(
+                "register the schemas of all topics matching the given regex"
+                    + "; does not do anything if --topic is specified").type(String.class);
+
+            SubCommand.addRootArgument(parser);
+        }
+    }
+
+    private static Properties loadConfig(final String configFile) throws IOException {
+        if (!Files.exists(Paths.get(configFile))) {
+            throw new IOException(configFile + " not found.");
+        }
+        final Properties cfg = new Properties();
+        try (InputStream inputStream = new FileInputStream(configFile)) {
+            cfg.load(inputStream);
+        }
+        return cfg;
+    }
+
+}

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/ConfluentCloudTopics.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/ConfluentCloudTopics.java
@@ -5,7 +5,6 @@ import static org.radarbase.util.Strings.isNullOrEmpty;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 import javax.validation.constraints.NotNull;
@@ -38,24 +37,17 @@ public class ConfluentCloudTopics extends AbstractTopicRegistrar {
 
     @Override
     AdminClient getKafkaClient() {
-        ensureInitialized();
         return kafkaClient;
     }
 
     @Override
     public void ensureInitialized() {
-        if (this.kafkaClient != null) {
-            throw new IllegalStateException("Kafka client is not initialized yet");
-        }
+        // instance is already initialized at object creation.
     }
 
     private Properties loadConfig(final String configFile) throws IOException {
-        Path filePath = Paths.get(configFile);
-        if (!Files.exists(filePath)) {
-            throw new IOException(configFile + " not found.");
-        }
         final Properties cfg = new Properties();
-        try (InputStream inputStream = Files.newInputStream(filePath)) {
+        try (InputStream inputStream = Files.newInputStream(Paths.get(configFile))) {
             cfg.load(inputStream);
         }
         return cfg;

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/ConfluentCloudTopics.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/ConfluentCloudTopics.java
@@ -70,9 +70,10 @@ public class ConfluentCloudTopics extends AbstractTopicRegistrar {
 
         @Override
         public int execute(Namespace options, CommandLineApp app) {
-            String configPath = options.getString("config-path");
+            String configPath = options.getString("config");
+            logger.debug("Config path is {}", configPath);
             if (isNullOrEmpty(configPath)) {
-                throw new IllegalArgumentException("--config-path not found. Confluent "
+                throw new IllegalArgumentException("--config not found. Confluent "
                         + "cloud config path cannot be empty");
             }
             short replication = options.getShort("replication");
@@ -91,7 +92,7 @@ public class ConfluentCloudTopics extends AbstractTopicRegistrar {
         @Override
         public void addParser(ArgumentParser parser) {
             parser.description("Create all topics that are missing on the Confluent Cloud env.");
-            parser.addArgument("-c", "--config-path").help("File path for Confluent cloud config")
+            parser.addArgument("-c", "--config").help("File path for Confluent cloud config")
                 .type(String.class);
             parser.addArgument("-p", "--partitions").help("number of partitions per topic")
                 .type(Integer.class).setDefault(3);

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/KafkaTopics.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/KafkaTopics.java
@@ -1,20 +1,13 @@
 package org.radarcns.schema.registration;
 
 import static org.apache.kafka.clients.admin.AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG;
-import static org.radarcns.schema.CommandLineApp.matchTopic;
 
-import java.io.Closeable;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.validation.constraints.NotNull;
+
 import kafka.cluster.Broker;
 import kafka.cluster.EndPoint;
 import kafka.zk.KafkaZkClient;
@@ -22,11 +15,8 @@ import kafka.zookeeper.ZooKeeperClientException;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.ListTopicsOptions;
-import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.utils.Time;
 import org.radarcns.schema.CommandLineApp;
-import org.radarcns.schema.specification.SourceCatalogue;
 import org.radarcns.schema.util.SubCommand;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,18 +27,17 @@ import scala.collection.Seq;
 /**
  * Registers Kafka topics with Zookeeper.
  */
-public class KafkaTopics implements Closeable {
+public class KafkaTopics extends AbstractTopicRegistrar {
     private static final Logger logger = LoggerFactory.getLogger(KafkaTopics.class);
-    private static final int MAX_SLEEP = 32;
 
     private final KafkaZkClient zkClient;
     private AdminClient kafkaClient;
     private String bootstrapServers;
-    private Set<String> topics;
     private boolean initialized;
 
     /**
      * Create Kafka topics registration object with given Zookeeper.
+     *
      * @param zookeeper comma-separated list of Zookeeper 'hostname:port'.
      */
     public KafkaTopics(@NotNull String zookeeper) {
@@ -62,9 +51,10 @@ public class KafkaTopics implements Closeable {
     /**
      * Wait for brokers to become available. This uses a polling mechanism,
      * waiting for at most 200 seconds.
+     *
      * @param brokers number of brokers to wait for
      * @return whether the brokers where available
-     * @throws InterruptedException when waiting for the brokers is interrupted.
+     * @throws InterruptedException     when waiting for the brokers is interrupted.
      * @throws ZooKeeperClientException if Zookeeper cannot be initialized.
      */
     public boolean initialize(int brokers) throws InterruptedException {
@@ -88,15 +78,13 @@ public class KafkaTopics implements Closeable {
                 kafkaClient = AdminClient.create(Map.of(
                         BOOTSTRAP_SERVERS_CONFIG, bootstrapServers));
             } else if (tries < numTries - 1) {
-                logger.warn(
-                        "Only {} out of {} Kafka brokers available. Waiting {} seconds.",
+                logger.warn("Only {} out of {} Kafka brokers available. Waiting {} seconds.",
                         numBrokers, brokers, sleep);
                 Thread.sleep(sleep * 1000L);
                 sleep = Math.min(MAX_SLEEP, sleep * 2);
             } else {
                 logger.error("Only {} out of {} Kafka brokers available."
-                                + " Failed to wait on all brokers.",
-                        numBrokers, brokers);
+                        + " Failed to wait on all brokers.", numBrokers, brokers);
             }
         }
 
@@ -104,68 +92,17 @@ public class KafkaTopics implements Closeable {
         return initialized && refreshTopics();
     }
 
-    private void ensureInitialized() {
+    @Override
+    public void ensureInitialized() {
         if (!initialized) {
             throw new IllegalStateException("Manager is not initialized yet");
         }
     }
 
-    /**
-     * Refresh the list of topics from Kafka.
-     * @return {@code true} if the update succeeded, {@code false} otherwise.
-     * @throws InterruptedException if the request was interrupted.
-     */
-    public boolean refreshTopics() throws InterruptedException {
-        ensureInitialized();
-        logger.info("Waiting for topics to become available.");
-        int sleep = 10;
-        int numTries = 10;
-
-        topics = null;
-        ListTopicsOptions opts = new ListTopicsOptions().listInternal(true);
-        for (int tries = 0; tries < numTries; tries++) {
-            try {
-                topics = kafkaClient.listTopics(opts).names()
-                        .get(sleep, TimeUnit.SECONDS);
-            } catch (ExecutionException e) {
-                logger.error("Failed to list topics from brokers: {}."
-                                + " Trying again after {} seconds.",
-                        e.toString(), sleep);
-                Thread.sleep(sleep * 1000L);
-                sleep = Math.min(MAX_SLEEP, sleep * 2);
-                continue;
-            } catch (TimeoutException e) {
-                // do nothing
-            }
-            if (topics != null && !topics.isEmpty()) {
-                break;
-            }
-            if (tries < numTries - 1) {
-                logger.warn("Topics not listed yet after {} seconds", sleep);
-            } else {
-                logger.error("Topics have not become available. Failed to wait on Kafka.");
-            }
-            sleep = Math.min(MAX_SLEEP, sleep * 2);
-        }
-
-        if (topics == null || topics.isEmpty()) {
-            return false;
-        } else {
-            Thread.sleep(5000L);
-            return true;
-        }
-    }
-
-    public Set<String> getTopics() {
-        ensureInitialized();
-        return Collections.unmodifiableSet(topics);
-    }
-
     private List<Broker> currentBrokers() {
         try {
             // convert Scala sequence of servers to Java
-            return asStream(zkClient.getAllBrokersInCluster())
-                    .collect(Collectors.toList());
+            return asStream(zkClient.getAllBrokersInCluster()).collect(Collectors.toList());
         } catch (ZooKeeperClientException ex) {
             logger.warn("Failed to reach zookeeper");
             return List.of();
@@ -179,57 +116,6 @@ public class KafkaTopics implements Closeable {
     public String getBootstrapServers() {
         ensureInitialized();
         return bootstrapServers;
-    }
-
-    /**
-     * Create all topics in a catalogue.
-     * @param catalogue source catalogue to extract topic names from
-     * @param partitions number of partitions per topic
-     * @param replication number of replicas for a topic
-     * @return whether the whole catalogue was registered
-     */
-    public boolean createTopics(@NotNull SourceCatalogue catalogue, int partitions,
-            short replication) {
-        ensureInitialized();
-        return createTopics(catalogue.getTopicNames(), partitions, replication);
-    }
-
-    /**
-     * Create a single topic.
-     * @param topics names of the topic to create
-     * @param partitions number of partitions per topic
-     * @param replication number of replicas for a topic
-     * @return whether the topic was registered
-     */
-    public boolean createTopics(Stream<String> topics, int partitions, short replication) {
-        ensureInitialized();
-        try {
-            logger.info("Creating topics. Topics marked with [*] already exist.");
-
-            List<NewTopic> newTopics = topics
-                    .sorted()
-                    .distinct()
-                    .filter(t -> {
-                        if (this.topics.contains(t)) {
-                            logger.info("[*] {}", t);
-                            return false;
-                        } else {
-                            logger.info("[ ] {}", t);
-                            return true;
-                        }
-                    })
-                    .map(t -> new NewTopic(t, partitions, replication))
-                    .collect(Collectors.toList());
-
-            if (!newTopics.isEmpty()) {
-                kafkaClient.createTopics(newTopics).all().get();
-                refreshTopics();
-            }
-            return true;
-        } catch (Exception ex) {
-            logger.error("Failed to create topics {}", ex.toString());
-            return false;
-        }
     }
 
     /**
@@ -255,10 +141,8 @@ public class KafkaTopics implements Closeable {
 
     @Override
     public void close() {
+        super.close();
         zkClient.close();
-        if (kafkaClient != null) {
-            kafkaClient.close();
-        }
     }
 
     /**
@@ -281,7 +165,7 @@ public class KafkaTopics implements Closeable {
 
             if (brokers < replication) {
                 logger.error("Cannot assign a replication factor {}"
-                                + " higher than number of brokers {}", replication, brokers);
+                        + " higher than number of brokers {}", replication, brokers);
                 return 1;
             }
 
@@ -292,28 +176,9 @@ public class KafkaTopics implements Closeable {
                     logger.error("Kafka brokers not yet available. Aborting.");
                     return 1;
                 }
-
-                Pattern pattern = matchTopic(
+                return topics.createTopics(app.getCatalogue(), partitions, replication,
                         options.getString("topic"), options.getString("match"));
 
-                if (pattern == null) {
-                    return topics.createTopics(app.getCatalogue(), partitions, replication) ? 0 : 1;
-                } else {
-                    List<String> topicNames = app.getCatalogue().getTopicNames()
-                            .filter(s -> pattern.matcher(s).find())
-                            .collect(Collectors.toList());
-
-                    if (topicNames.isEmpty()) {
-                        logger.error("Topic {} does not match a known topic."
-                                        + " Find the list of acceptable topics"
-                                        + " with the `radar-schemas-tools list` command. Aborting.",
-                                pattern);
-                        return 1;
-                    }
-
-                    return topics.createTopics(topicNames.stream(), partitions, replication)
-                            ? 0 : 1;
-                }
             } catch (InterruptedException | ZooKeeperClientException e) {
                 logger.error("Cannot retrieve number of addActive Kafka brokers."
                         + " Please check that Zookeeper is running.");

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/KafkaTopics.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/KafkaTopics.java
@@ -134,6 +134,7 @@ public class KafkaTopics extends AbstractTopicRegistrar {
     }
 
     @NotNull
+    @Override
     public AdminClient getKafkaClient() {
         ensureInitialized();
         return kafkaClient;

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/SchemaRegistry.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/SchemaRegistry.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.Namespace;
@@ -39,11 +40,11 @@ import okio.BufferedSink;
 import org.radarbase.config.ServerConfig;
 import org.radarbase.producer.rest.RestClient;
 import org.radarbase.producer.rest.SchemaRetriever;
+import org.radarbase.topic.AvroTopic;
 import org.radarcns.schema.CommandLineApp;
 import org.radarcns.schema.specification.DataProducer;
 import org.radarcns.schema.specification.SourceCatalogue;
 import org.radarcns.schema.util.SubCommand;
-import org.radarbase.topic.AvroTopic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -183,8 +184,7 @@ public class SchemaRegistry {
                 if (isNullOrEmpty(apiKey) || isNullOrEmpty(apiSecret)) {
                     logger.info("Initializing standard SchemaRegistration ...");
                     registration = new SchemaRegistry(url);
-                }
-                else {
+                } else {
                     logger.info("Initializing SchemaRegistration with authentication...");
                     registration = new SchemaRegistry(url, apiKey, apiSecret);
                 }

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/SchemaRegistry.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/SchemaRegistry.java
@@ -78,11 +78,10 @@ public class SchemaRegistry {
             throws MalformedURLException {
         ServerConfig config = new ServerConfig(baseUrl);
         config.setUnsafe(true);
-        String credential = Credentials.basic(apiKey, apiSecret);
         this.httpClient = RestClient.global()
                 .timeout(10, TimeUnit.SECONDS)
                 .server(config)
-                .headers(Headers.of("Authorization", credential))
+                .headers(Headers.of("Authorization", Credentials.basic(apiKey, apiSecret)))
                 .build();
         this.schemaClient = new SchemaRetriever(this.httpClient);
     }

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/SchemaRegistry.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/SchemaRegistry.java
@@ -177,8 +177,8 @@ public class SchemaRegistry {
         @Override
         public int execute(Namespace options, CommandLineApp app) {
             String url = options.get("schemaRegistry");
-            String apiKey = options.getString("api-key");
-            String apiSecret = options.getString("api-secret");
+            String apiKey = options.getString("api_key");
+            String apiSecret = options.getString("api_secret");
             try {
                 SchemaRegistry registration;
                 if (isNullOrEmpty(apiKey) || isNullOrEmpty(apiSecret)) {

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/SchemaRegistry.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/SchemaRegistry.java
@@ -67,7 +67,7 @@ public class SchemaRegistry {
      */
     public SchemaRegistry(String baseUrl) throws MalformedURLException {
         ServerConfig config = new ServerConfig(baseUrl);
-        config.setUnsafe(true);
+        config.setUnsafe(false);
         this.httpClient = RestClient.global()
             .timeout(10, TimeUnit.SECONDS)
             .server(config)

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/TopicRegistrar.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/TopicRegistrar.java
@@ -7,16 +7,51 @@ import javax.validation.constraints.NotNull;
 
 import org.radarcns.schema.specification.SourceCatalogue;
 
+/**
+ * Registers topic on configured Kafka environment.
+ */
 public interface TopicRegistrar extends Closeable {
 
+    /**
+     * Create all topics in a catalogue based on pattern provided.
+     *
+     * @param catalogue   source catalogue to extract topic names from.
+     * @param partitions  number of partitions per topic.
+     * @param replication number of replicas for a topic.
+     * @param topic Topic name if registering the schemas only for topic.
+     * @param match Regex string to register schemas only for topics that match the pattern.
+     * @return 0 if execution was successful. 1 otherwise.
+     */
     int createTopics(@NotNull SourceCatalogue catalogue, int partitions, short replication,
             String topic, String match);
 
+    /**
+     * Create a single topic.
+     *
+     * @param topics      names of the topic to create.
+     * @param partitions  number of partitions per topic.
+     * @param replication number of replicas for a topic.
+     * @return whether the topic was registered.
+     */
     boolean createTopics(Stream<String> topics, int partitions, short replication);
 
+    /**
+     * Ensures this topicRegistrar instance is initialized for use.
+     */
     void ensureInitialized();
 
+    /**
+     * Updates the list of topics from Kafka.
+     *
+     * @return {@code true} if the update succeeded, {@code false} otherwise.
+     * @throws InterruptedException if the request was interrupted.
+     */
     boolean refreshTopics() throws InterruptedException;
 
+    /**
+     * Returns the list of topics from Kafka.
+     *
+     * @return {@code List<String>} list of topics.
+     */
     Set<String> getTopics();
 }

--- a/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/TopicRegistrar.java
+++ b/java-sdk/radar-schemas-tools/src/main/java/org/radarcns/schema/registration/TopicRegistrar.java
@@ -1,0 +1,22 @@
+package org.radarcns.schema.registration;
+
+import java.io.Closeable;
+import java.util.Set;
+import java.util.stream.Stream;
+import javax.validation.constraints.NotNull;
+
+import org.radarcns.schema.specification.SourceCatalogue;
+
+public interface TopicRegistrar extends Closeable {
+
+    int createTopics(@NotNull SourceCatalogue catalogue, int partitions, short replication,
+            String topic, String match);
+
+    boolean createTopics(Stream<String> topics, int partitions, short replication);
+
+    void ensureInitialized();
+
+    boolean refreshTopics() throws InterruptedException;
+
+    Set<String> getTopics();
+}


### PR DESCRIPTION
- Adds a new command to register topics to Confluent Cloud 
- Adds an option to register schemas with authorization, that can be used on Confluent Cloud based Schema registry
- Updates to latest `radar-commons`