### PR TITLE
Exclude unwanted specifications

### DIFF
--- a/Dockerfile.kafkaInit
+++ b/Dockerfile.kafkaInit
@@ -48,6 +48,7 @@ COPY --from=builder /code ./original
 
 VOLUME /schema/conf
 # Copy bash file
+COPY ./docker/specifications.exclude /etc/radar-schemas/specifications.exclude
 COPY ./docker/topic_init.sh ./docker/init.sh ./docker/list_aggregated.sh ./docker/list_raw.sh /usr/bin/
 RUN chmod +x /usr/bin/*.sh
 

--- a/README.md
+++ b/README.md
@@ -79,24 +79,24 @@ docker-compose run --rm tools radar-schemas-tools schema-topic --ensure -f schem
 
     1.1. Create a `java-config.properties` file. A Confluent Cloud config for Java application based on this [template](https://github.com/confluentinc/configuration-templates/blob/master/clients/cloud/java-sr.config).
 
-        ```properties
-        # Kafka
-        bootstrap.servers={{ BROKER_ENDPOINT }}
-        security.protocol=SASL_SSL
-        sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
-        ssl.endpoint.identification.algorithm=https
-        sasl.mechanism=PLAIN
+    ```properties
+    # Kafka
+    bootstrap.servers={{ BROKER_ENDPOINT }}
+    security.protocol=SASL_SSL
+    sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="{{ CLUSTER_API_KEY }}" password="{{ CLUSTER_API_SECRET }}";
+    ssl.endpoint.identification.algorithm=https
+    sasl.mechanism=PLAIN
 
-        # Confluent Cloud Schema Registry
-        schema.registry.url=https://{{ SR_ENDPOINT }}
-        basic.auth.credentials.source=USER_INFO
-        schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
-        ```
+    # Confluent Cloud Schema Registry
+    schema.registry.url=https://{{ SR_ENDPOINT }}
+    basic.auth.credentials.source=USER_INFO
+    schema.registry.basic.auth.user.info={{ SR_API_KEY }}:{{ SR_API_SECRET }}
+    ```
     1.2. Run `cc-topic-create` command
 
-        ```
-        docker run --rm -v "$PWD/java-config.properties:/schema/conf/java.properties" radarbase/kafka-init radar-schemas-tools cc-topic-create -c java-config.properties
-        ```
+    ```
+    docker run --rm -v "$PWD/java-config.properties:/schema/conf/java.properties" radarbase/kafka-init radar-schemas-tools cc-topic-create -c java-config.properties
+    ```
         
 2. Register schemas on Confluent Cloud schema registry
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@
 - The `specifications` directory contains specifications of what data types are collected through which devices.
 - Java SDKs for each of the components are provided in the `java-sdk` folder, see installation instructions there. They are automatically generated from the Avro schemas using the Avro 1.8.2 specification.
 
+## Usage
+
+This project can be used in RADAR-base by using the `radarbase/kafka-init` Docker image. The schemas and specifications can be extended by locally creating a directory structure that includes a `commons` and `specifications` directory and mounting it to the image, to the `/schema/conf/commons` and `/schema/conf/specifications` directories, respectively. Existing specifications can be excluded from your deployment by mounting a file at `/etc/radar-schemas/specifications.exclude`, with on each line a file pattern that can be excluded. The pattern should start from the `specifications` directory as parent directory. Example file contents:
+```
+active/*
+passive/biovotion*
+```
+
 ## Contributing
 
 The Avro schemas should follow the [Google JSON style guide](https://google.github.io/styleguide/jsoncstyleguide.xml).
@@ -64,3 +72,4 @@ docker-compose run --rm tools radar-schemas-tools schema-topic --backup -f schem
 # ensure the validity of the _schemas topic
 docker-compose run --rm tools radar-schemas-tools schema-topic --ensure -f schema.json -b 1 -r 1 zookeeper-1:2181
 ```
+


### PR DESCRIPTION
By setting or overriding `/etc/radar-schemas/specifications.exclude`, a user can exclude certain specifications from being registered by `kafka-init`.