### PR TITLE
Update Altoida summary metrics schema

### DIFF
--- a/commons/connector/upload/altoida/altoida_summary.avsc
+++ b/commons/connector/upload/altoida/altoida_summary.avsc
@@ -19,11 +19,6 @@
               "type": "enum",
               "doc": "Classifications provided by Altoida.",
               "symbols": ["HEALTHY", "AT_RISK", "MCI_DUE_TO_AD"]}], "doc": "Classification based on the analysis  0=healthy, 1=at risk, 2=MCI due to AD.", "default": null},
-    {"name": "nmi", "type": "double", "doc": "NMI value of the test,a value in 0-100, where 0-33.3 is class 2, 33.3-66.6 is class 1, 66.6-100 is class 0."},
-    {"name": "groundTruth", "type": {
-              "name": "GroundTruth",
-              "type": "enum",
-              "doc": "GroundTruth supported by Altoida.",
-              "symbols": ["UNKNOWN", "HEALTHY", "AT_RISK", "MCI_OR_AB_PLUS", "MCI_OR_AB_MINUS"]}, "doc": "If the test is based on additional biomarkers -1=unknown, 0=healthy, 1= at risk, 2=MCI/AB+, 3=MCI/AB-.", "default": "UNKNOWN"}
+    {"name": "nmi", "type": "double", "doc": "NMI value of the test,a value in 0-100, where 0-33.3 is class 2, 33.3-66.6 is class 1, 66.6-100 is class 0."}
   ]
 }

--- a/commons/connector/upload/altoida/altoida_summary_metrics.avsc
+++ b/commons/connector/upload/altoida/altoida_summary_metrics.avsc
@@ -8,7 +8,7 @@
     {"name": "timeReceived", "type": "double", "doc": "Timestamp in unix time received from Altoida API."},
     {"name": "audioHighReactionTimes", "type": "float", "doc": "Distribution of reaction times to high tone(s)."},
     {"name": "audioHighAccuracy", "type": "float", "doc": "Distribution of deviation from speaker button center (cm)."},
-    {"name": "audioLowReactions", "type": "int", "doc": "Distributions of number of reactions to low tones."},
+    {"name": "audioLowReactions", "type": ["null","int"], "doc": "Distributions of number of reactions to low tones."},
     {"name": "audioIgnoredHighTonePercentage", "type": "float", "doc": "Distribution of ratio of high tones ignored."},
     {"name": "audioPrematureToneButtonPresses", "type": "int", "doc": "Distribution of number of premature tone button presses."},
     {"name": "randomScreenPressesDuringPlacement", "type": "int", "doc": "Distribution of number of random screen presses during the placement phase."},

--- a/commons/connector/upload/altoida/altoida_summary_metrics.avsc
+++ b/commons/connector/upload/altoida/altoida_summary_metrics.avsc
@@ -8,7 +8,7 @@
     {"name": "timeReceived", "type": "double", "doc": "Timestamp in unix time received from Altoida API."},
     {"name": "audioHighReactionTimes", "type": "float", "doc": "Distribution of reaction times to high tone(s)."},
     {"name": "audioHighAccuracy", "type": "float", "doc": "Distribution of deviation from speaker button center (cm)."},
-    {"name": "audioLowReactions", "type": ["null", "int"], "doc": "Distributions of number of reactions to low tones."},
+    {"name": "audioLowReactions", "type": ["null", "int"], "doc": "Distributions of number of reactions to low tones.", "default": null},
     {"name": "audioIgnoredHighTonePercentage", "type": "float", "doc": "Distribution of ratio of high tones ignored."},
     {"name": "audioPrematureToneButtonPresses", "type": "int", "doc": "Distribution of number of premature tone button presses."},
     {"name": "randomScreenPressesDuringPlacement", "type": "int", "doc": "Distribution of number of random screen presses during the placement phase."},

--- a/commons/connector/upload/altoida/altoida_summary_metrics.avsc
+++ b/commons/connector/upload/altoida/altoida_summary_metrics.avsc
@@ -8,7 +8,7 @@
     {"name": "timeReceived", "type": "double", "doc": "Timestamp in unix time received from Altoida API."},
     {"name": "audioHighReactionTimes", "type": "float", "doc": "Distribution of reaction times to high tone(s)."},
     {"name": "audioHighAccuracy", "type": "float", "doc": "Distribution of deviation from speaker button center (cm)."},
-    {"name": "audioLowReactions", "type": ["null","int"], "doc": "Distributions of number of reactions to low tones."},
+    {"name": "audioLowReactions", "type": ["null", "int"], "doc": "Distributions of number of reactions to low tones."},
     {"name": "audioIgnoredHighTonePercentage", "type": "float", "doc": "Distribution of ratio of high tones ignored."},
     {"name": "audioPrematureToneButtonPresses", "type": "int", "doc": "Distribution of number of premature tone button presses."},
     {"name": "randomScreenPressesDuringPlacement", "type": "int", "doc": "Distribution of number of random screen presses during the placement phase."},


### PR DESCRIPTION
- Make `audioLowReactions` nullable since this is only present in the `DOT` test and not in the `BIT` test
- Remove `groundTruth` since this is not present anymore