### PR TITLE
Improve retry on topic creation

### DIFF
--- a/docker/topic_init.sh
+++ b/docker/topic_init.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+MAX_RETRIES=5
+
 if [ -z NO_VALIDATE ]; then
   radar-schemas-tools validate merged
 fi
@@ -7,17 +9,21 @@ fi
 # Create topics
 echo "Creating RADAR-base topics..."
 
-if ! radar-schemas-tools create -c "${KAFKA_CONFIG_PATH}" -p $KAFKA_NUM_PARTITIONS -r $KAFKA_NUM_REPLICATION -b $KAFKA_NUM_BROKERS -s "${KAFKA_BOOTSTRAP_SERVERS}" merged; then
-  echo "FAILED TO CREATE TOPICS ... Retrying"
-  if ! radar-schemas-tools create -c "${KAFKA_CONFIG_PATH}" -p $KAFKA_NUM_PARTITIONS -r $KAFKA_NUM_REPLICATION -b $KAFKA_NUM_BROKERS -s "${KAFKA_BOOTSTRAP_SERVERS}" merged; then
-    echo "FAILED TO CREATE TOPICS"
-    exit 1
-  else
-    echo "Created topics at second attempt"
-  fi
-else
-  echo "Topics created."
-fi
+for ((i=1; i<=$MAX_RETRIES; i++)); do
+    if radar-schemas-tools create -c "${KAFKA_CONFIG_PATH}" -p $KAFKA_NUM_PARTITIONS -r $KAFKA_NUM_REPLICATION -b $KAFKA_NUM_BROKERS -s "${KAFKA_BOOTSTRAP_SERVERS}" merged; then
+        echo "Created topics at attempt $i"
+        break
+    else
+        if [ $i -eq $MAX_RETRIES ]; then
+            echo "FAILED TO CREATE TOPICS AFTER $i ATTEMPT(S)"
+            exit 1
+        else
+            echo "FAILED TO CREATE TOPICS ... Retrying"
+            sleep 10
+        fi
+    fi
+done
+echo "Topics created."
 
 echo "Registering RADAR-base schemas..."
 if ! radar-schemas-tools register --force -u "$SCHEMA_REGISTRY_API_KEY" -p "$SCHEMA_REGISTRY_API_SECRET" "${KAFKA_SCHEMA_REGISTRY}" merged; then

--- a/docker/topic_init.sh
+++ b/docker/topic_init.sh
@@ -19,7 +19,6 @@ for ((i=1; i<=$MAX_RETRIES; i++)); do
             exit 1
         else
             echo "FAILED TO CREATE TOPICS ... Retrying"
-            sleep 10
         fi
     fi
 done


### PR DESCRIPTION
The starting up of the `radar-schemas-tools` docker image could fail after the "double-checked" topic creation due to unavailable brokers. This PR tries to improve the retry logic.  