### PR TITLE
Add new resource fields restingHeartRate and sleep efficiency

### DIFF
--- a/commons/connector/fitbit/fitbit_activity_heart_rate.avsc
+++ b/commons/connector/fitbit/fitbit_activity_heart_rate.avsc
@@ -13,6 +13,7 @@
     {"name": "durationOutOfRange", "type": ["null", "int"], "doc": "Duration in the heart rate zone 'Out Of Range', which is the lowest heart rate zone (s). Null if unknown.", "default": null},
     {"name": "durationFatBurn", "type": ["null", "int"], "doc": "Duration in the heart rate zone 'Fat Burn', which is the second lowest heart rate zone (s). Null if unknown.", "default": null},
     {"name": "durationCardio", "type": ["null", "int"], "doc": "Duration in the heart rate zone 'Cardio', which is the third lowest heart rate zone (s). Null if unknown.", "default": null},
-    {"name": "durationPeak", "type": ["null", "int"], "doc": "Duration in the heart rate zone 'Peak', which is the highest heart rate zone (s). Null if unknown.", "default": null}
+    {"name": "durationPeak", "type": ["null", "int"], "doc": "Duration in the heart rate zone 'Peak', which is the highest heart rate zone (s). Null if unknown.", "default": null},
+    { "name": "restingHeartRate", "type": ["null", "int"], "doc": "Resting heart rate value (bpm) for the day. A sleep stage log is required to generate this value. When a classic sleep log is recorded, this value will be missing.", "default": null }
   ]
 }

--- a/commons/connector/fitbit/fitbit_intraday_heart_rate.avsc
+++ b/commons/connector/fitbit/fitbit_intraday_heart_rate.avsc
@@ -8,6 +8,6 @@
     { "name": "timeReceived", "type": "double", "doc": "Time that the data was received from the Fitbit API (seconds since the Unix Epoch)." },
     { "name": "timeInterval", "type": "int", "doc":  "Chronological window size (s)." },
     { "name": "heartRate", "type": "int", "doc": "Heart rate value (bpm)."},
-    { "name": "restingHeartRate", "type": "int", "doc": "Resting heart rate value for the day. A sleep stage log is required to generate this value. When a classic sleep log is recorded, this value will be missing." }
+    { "name": "restingHeartRate", "type": ["null", "int"], "doc": "Resting heart rate value for the day. A sleep stage log is required to generate this value. When a classic sleep log is recorded, this value will be missing.", "default": null }
   ]
 }

--- a/commons/connector/fitbit/fitbit_intraday_heart_rate.avsc
+++ b/commons/connector/fitbit/fitbit_intraday_heart_rate.avsc
@@ -8,6 +8,6 @@
     { "name": "timeReceived", "type": "double", "doc": "Time that the data was received from the Fitbit API (seconds since the Unix Epoch)." },
     { "name": "timeInterval", "type": "int", "doc":  "Chronological window size (s)." },
     { "name": "heartRate", "type": "int", "doc": "Heart rate value (bpm)."},
-    { "name": "restingHeartRate", "type": ["null", "int"], "doc": "Resting heart rate value for the day. A sleep stage log is required to generate this value. When a classic sleep log is recorded, this value will be missing.", "default": null }
+    { "name": "restingHeartRate", "type": ["null", "int"], "doc": "Resting heart rate value (bpm) for the day. A sleep stage log is required to generate this value. When a classic sleep log is recorded, this value will be missing.", "default": null }
   ]
 }

--- a/commons/connector/fitbit/fitbit_intraday_heart_rate.avsc
+++ b/commons/connector/fitbit/fitbit_intraday_heart_rate.avsc
@@ -7,6 +7,7 @@
     { "name": "time", "type": "double", "doc": "Device timestamp in UTC (s)." },
     { "name": "timeReceived", "type": "double", "doc": "Time that the data was received from the Fitbit API (seconds since the Unix Epoch)." },
     { "name": "timeInterval", "type": "int", "doc":  "Chronological window size (s)." },
-    { "name": "heartRate", "type": "int", "doc": "Heart rate value (bpm)."}
+    { "name": "heartRate", "type": "int", "doc": "Heart rate value (bpm)."},
+    { "name": "restingHeartRate", "type": "int", "doc": "Resting heart rate value for the day. A sleep stage log is required to generate this value. When a classic sleep log is recorded, this value will be missing." }
   ]
 }

--- a/commons/connector/fitbit/fitbit_sleep_classic.avsc
+++ b/commons/connector/fitbit/fitbit_sleep_classic.avsc
@@ -10,6 +10,6 @@
     { "name": "level", "type":
       { "name": "FitbitSleepClassicLevel", "type": "enum", "symbols": ["AWAKE", "RESTLESS", "ASLEEP", "UNKNOWN"], "doc": "Level of sleep as computed by Fitbit."},
       "doc": "Level of sleep as computed by Fitbit.", "default": "UNKNOWN" },
-    { "name": "efficiency", "type": ["null", "int"], "doc": "Calculated sleep efficiency score", "default": null }
+    { "name": "efficiency", "type": ["null", "int"], "doc": "Calculated sleep efficiency score (in percentage). It is a percentage of the amount of time the user was asleep (and not restless) divided by the time they spent in the bed after initially falling asleep.", "default": null }
   ]
 }

--- a/commons/connector/fitbit/fitbit_sleep_classic.avsc
+++ b/commons/connector/fitbit/fitbit_sleep_classic.avsc
@@ -9,6 +9,7 @@
     { "name": "duration", "type": "int", "doc": "Duration at this sleep characteristic in seconds." },
     { "name": "level", "type":
       { "name": "FitbitSleepClassicLevel", "type": "enum", "symbols": ["AWAKE", "RESTLESS", "ASLEEP", "UNKNOWN"], "doc": "Level of sleep as computed by Fitbit."},
-      "doc": "Level of sleep as computed by Fitbit.", "default": "UNKNOWN" }
+      "doc": "Level of sleep as computed by Fitbit.", "default": "UNKNOWN" },
+    { "name": "efficiency", "type": "string", "doc": "Calculated sleep efficiency score" }
   ]
 }

--- a/commons/connector/fitbit/fitbit_sleep_classic.avsc
+++ b/commons/connector/fitbit/fitbit_sleep_classic.avsc
@@ -10,6 +10,6 @@
     { "name": "level", "type":
       { "name": "FitbitSleepClassicLevel", "type": "enum", "symbols": ["AWAKE", "RESTLESS", "ASLEEP", "UNKNOWN"], "doc": "Level of sleep as computed by Fitbit."},
       "doc": "Level of sleep as computed by Fitbit.", "default": "UNKNOWN" },
-    { "name": "efficiency", "type": "string", "doc": "Calculated sleep efficiency score" }
+    { "name": "efficiency", "type": ["null", "int"], "doc": "Calculated sleep efficiency score", "default": null }
   ]
 }

--- a/commons/connector/fitbit/fitbit_sleep_stage.avsc
+++ b/commons/connector/fitbit/fitbit_sleep_stage.avsc
@@ -10,6 +10,6 @@
     { "name": "level", "type":
       {"name": "FitbitSleepStageLevel", "type": "enum", "symbols": ["DEEP", "LIGHT", "REM", "AWAKE", "UNKNOWN"], "doc": "Level of sleep as computed by Fitbit."},
       "doc": "Level of sleep as computed by Fitbit.", "default": "UNKNOWN" },
-    { "name": "efficiency", "type": "string", "doc": "Calculated sleep efficiency score" }
+    { "name": "efficiency", "type": ["null", "int"], "doc": "Calculated sleep efficiency score", "default": null }
   ]
 }

--- a/commons/connector/fitbit/fitbit_sleep_stage.avsc
+++ b/commons/connector/fitbit/fitbit_sleep_stage.avsc
@@ -10,6 +10,6 @@
     { "name": "level", "type":
       {"name": "FitbitSleepStageLevel", "type": "enum", "symbols": ["DEEP", "LIGHT", "REM", "AWAKE", "UNKNOWN"], "doc": "Level of sleep as computed by Fitbit."},
       "doc": "Level of sleep as computed by Fitbit.", "default": "UNKNOWN" },
-    { "name": "efficiency", "type": ["null", "int"], "doc": "Calculated sleep efficiency score", "default": null }
+    { "name": "efficiency", "type": ["null", "int"], "doc": "Calculated sleep efficiency score (in percentage). It is a percentage of the amount of time the user was asleep (and not restless) divided by the time they spent in the bed after initially falling asleep.", "default": null }
   ]
 }

--- a/commons/connector/fitbit/fitbit_sleep_stage.avsc
+++ b/commons/connector/fitbit/fitbit_sleep_stage.avsc
@@ -9,6 +9,7 @@
     { "name": "duration", "type": "int", "doc": "Duration at this sleep characteristic in seconds." },
     { "name": "level", "type":
       {"name": "FitbitSleepStageLevel", "type": "enum", "symbols": ["DEEP", "LIGHT", "REM", "AWAKE", "UNKNOWN"], "doc": "Level of sleep as computed by Fitbit."},
-      "doc": "Level of sleep as computed by Fitbit.", "default": "UNKNOWN" }
+      "doc": "Level of sleep as computed by Fitbit.", "default": "UNKNOWN" },
+    { "name": "efficiency", "type": "string", "doc": "Calculated sleep efficiency score" }
   ]
 }


### PR DESCRIPTION
This PR is related to the issue [#89](https://github.com/RADAR-base/RADAR-REST-Connector/issues/89)

Changes made in the PR:
- Add `restingHeartRate` field to the intraday heart rate schema
- Add `efficiency` field to the sleep classic and stage schemas
