### PR TITLE
Make docker login optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,32 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      - name: Docker build parameters
+        id: docker_params
+        run: |
+          echo "::set-output name=has_docker_login::${{ secrets.DOCKERHUB_USERNAME != ''  && secrets.DOCKERHUB_TOKEN != '' }}"
+          if [ "${{ github.event_name == 'pull_request' }}" = "true" ]; then
+            echo "::set-output name=push::false"
+            echo "::set-output name=load::true"
+            echo "::set-output name=platforms::linux/amd64"
+          else
+            echo "::set-output name=push::true"
+            echo "::set-output name=load::false"
+            echo "::set-output name=platforms::linux/amd64,linux/arm64"
+          fi
+
+      - name: Cache Docker layers
+        id: cache_buildx
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ steps.docker_params.outputs.push }}-${{ hashFiles('**/Dockerfile', '**/*.gradle', 'gradle.properties', '.dockerignore', '*/src/main/**', 'docker/**') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ steps.docker_params.outputs.push }}-
+            ${{ runner.os }}-buildx-
+
       - name: Login to Docker Hub
+        if: steps.docker_params.outputs.has_docker_login == 'true'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -70,19 +95,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Cache Docker layers
-        id: cache-buildx
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile', 'java-sdk/**/*.gradle', 'java-sdk/gradle.properties', 'java-sdk/*/src/main/**', 'commons/**', 'specifications/**', 'docker/**') }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Cache parameters
         id: cache-parameters
         run: |
-          if [ "${{ steps.cache-buildx.outputs.cache-hit }}" = "true" ]; then
+          if [ "${{ steps.cache_buildx.outputs.cache-hit }}" = "true" ]; then
             echo "::set-output name=cache-to::"
           else
             echo "::set-output name=cache-to::type=local,dest=/tmp/.buildx-cache-new,mode=max"
@@ -93,7 +109,9 @@ jobs:
         with:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: ${{ steps.cache-parameters.outputs.cache-to }}
-          load: true
+          platforms: ${{ steps.docker_params.outputs.platforms }}
+          load: ${{ steps.docker_params.outputs.load }}
+          push: ${{ steps.docker_params.outputs.push }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           # Use runtime labels from docker_meta as well as fixed labels
           labels: |
@@ -103,6 +121,10 @@ jobs:
             org.opencontainers.image.authors=Joris Borgdorff <joris@thehyve.nl>, Yatharth Ranjan <yatharth.ranjan@kcl.ac.uk>, Pauline Conde <pauline.conde@kcl.ac.uk>
             org.opencontainers.image.vendor=RADAR-base
             org.opencontainers.image.licenses=Apache-2.0
+
+      - name: Pull docker image
+        if: steps.docker_params.outputs.load == 'false'
+        run: docker pull ${{ env.DOCKER_IMAGE }}:${{ steps.docker_meta.outputs.version }}
 
       - name: Inspect docker image
         run: docker image inspect ${{ env.DOCKER_IMAGE }}:${{ steps.docker_meta.outputs.version }}
@@ -121,7 +143,7 @@ jobs:
       # https://github.com/docker/build-push-action/issues/252
       # https://github.com/moby/buildkit/issues/1896
       - name: Move docker build cache
-        if: steps.cache-buildx.outputs.cache-hit != 'true'
+        if: steps.cache_buildx.outputs.cache-hit != 'true'
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ steps.docker_params.outputs.push }}-${{ hashFiles('**/Dockerfile', '**/*.gradle', 'gradle.properties', '.dockerignore', '*/src/main/**', 'docker/**') }}
+          key: ${{ runner.os }}-buildx-${{ steps.docker_params.outputs.push }}-${{ hashFiles('Dockerfile', 'java-sdk/**/*.gradle', 'java-sdk/gradle.properties', 'java-sdk/*/src/main/**', 'commons/**', 'specifications/**', 'docker/**') }}
           restore-keys: |
             ${{ runner.os }}-buildx-${{ steps.docker_params.outputs.push }}-
             ${{ runner.os }}-buildx-


### PR DESCRIPTION
Github actions will no longer do a docker login for external contributors.
Additionally, build all docker images for all platforms, also in `dev`.