### PR TITLE
Add general aRMT topic

### DIFF
--- a/specifications/active/aRMT-1.0.0-general.yml
+++ b/specifications/active/aRMT-1.0.0-general.yml
@@ -1,0 +1,23 @@
+name: aRMT-general
+vendor: RADAR
+model: aRMT-App
+version: 1.0.0-general
+assessment_type: QUESTIONNAIRE
+doc: General topics used by the aRMT app, including metadata and monitoring information.
+data:
+  - type: QUESTIONNAIRE_RESPONSE
+    topic: questionnaire_response
+    doc: General questionnaire response topic, if the topic specific to the questionnaire does not exist.
+    value_schema: .active.questionnaire.Questionnaire
+  - type: COMPLETION_LOG
+    doc: Information about the completeness of each questionnaire.
+    topic: questionnaire_completion_log
+    value_schema: .monitor.questionnaire.QuestionnaireCompletionLog
+  - type: TIMEZONE
+    doc: Timezone information sent along with each questionnaire.
+    topic: questionnaire_timezone
+    value_schema: .monitor.application.ApplicationTimeZone
+  - type: APP_EVENT
+    doc: Questionnaire application interaction event.
+    topic: questionnaire_app_event
+    value_schema: .monitor.questionnaire.QuestionnaireApplicationInteractionEvent

--- a/specifications/active/aRMT-1.17.0.yml
+++ b/specifications/active/aRMT-1.17.0.yml
@@ -1,0 +1,299 @@
+name: aRMT
+vendor: RADAR
+model: aRMT-App
+version: 1.17.0
+assessment_type: QUESTIONNAIRE
+doc: aRMT Questionnaires definition. Includes Personal Health Questionnaire Depression Scale (PHQ-8), Experience sampling method (ESM) and RSES and other data.
+data:
+  - type: THINC_IT
+    topic: notification_thinc_it
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/blob/master/questionnaires/thinc_it/thinc_it_armt.json
+  - type: ROMBERG_TEST
+    doc: The value of the task is in milliseconds (ms).
+    topic: task_romberg_test
+    value_schema: .active.task.Task
+    questionnaire_definition_url: https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/blob/master/questionnaires/romberg_test/romberg_test_armt.json
+  - type: 2MW_TEST
+    doc: The value of the task is in milliseconds (ms).
+    topic: task_2MW_test
+    value_schema: .active.task.Task
+    questionnaire_definition_url: https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/blob/master/questionnaires/2MW_test/2MW_test_armt.json
+  - type: TANDEM_WALKING_TEST
+    doc: The value of the task is in milliseconds (ms).
+    topic: task_tandem_walking_test
+    value_schema: .active.task.Task
+    questionnaire_definition_url: https://github.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/blob/master/questionnaires/tandem_walking_test/tandem_walking_test_armt.json
+  - type: PHQ8
+    topic: questionnaire_phq8
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/phq8/phq8_armt.json
+  - type: ESM
+    topic: questionnaire_esm
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/esm/esm_armt.json
+  - type: AUDIO
+    doc: A speech questionnaire that contain two parts, a scripted text part where users will record themselves reading a text aloud, and an unscripted text part where users will record themselves answering a question.
+    topic: questionnaire_audio
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/audio/audio_armt.json
+  - type: AUDIO_2
+    doc: A speech questionnaire that contain two parts, a scripted text part where users will record themselves reading a text aloud, and an unscripted text part where users will record themselves answering a question.
+    topic: questionnaire_audio
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/audio_2/audio_2_armt.json
+  - type: AUDIO_3
+    doc: A speech questionnaire that contain two parts, a scripted text part where users will record themselves reading a text aloud, and an unscripted text part where users will record themselves answering a question.
+    topic: questionnaire_audio
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/audio_3/audio_3_armt.json
+  - type: AUDIO_4
+    topic: questionnaire_audio
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/audio_4/audio_4_armt.json
+  - type: RSES
+    topic: questionnaire_rses
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/rses/rses_armt.json
+  - type: PERCEIVED_DEFICITS_QUESTIONNAIRE
+    topic: questionnaire_perceived_deficits_questionnaire
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/perceived_deficits_questionnaire/perceived_deficits_questionnaire_armt.json
+  - type: PATIENT_DETERMINED_DISEASE_STEP
+    topic: questionnaire_patient_determined_disease_step
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/patient_determined_disease_step/patient_determined_disease_step_armt.json
+  - type: ESM28Q
+    topic: questionnaire_esm28q
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/esm28q/esm28q_armt.json
+  - type: BIPQ
+    topic: questionnaire_bipq
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/bipq/bipq_armt.json
+  - type: ESM_EPI_MOD_1
+    topic: questionnaire_esm_epi_mod_1
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/esm_epi_mod_1/esm_epi_mod_1_armt.json
+  - type: EVENING_ASSESSMENT
+    topic: questionnaire_evening_assessment
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/evening_assessment/evening_assessment_armt.json
+  - type: MORNING_ASSESSMENT
+    topic: questionnaire_morning_assessment
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/morning_assessment/morning_assessment_armt.json
+  - type: TAM
+    topic: questionnaire_tam
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/tam/tam_armt.json
+  - type: BAARS_IV
+    topic: questionnaire_baars_iv
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/baars_iv/baars_iv_armt.json
+  - type: ARI_SELF
+    topic: questionnaire_ari_self
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/ari_self/ari_self_armt.json
+  - type: GAD7
+    topic: questionnaire_gad7
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/gad7/gad7_armt.json
+  - type: RPQ
+    topic: questionnaire_rpq
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/rpq/rpq_armt.json
+  - type: ART_COGNITIVE_TEST
+    topic: questionnaire_art_cognitive_test
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/art_cognitive_test/art_cognitive_test_armt.json
+  - type: COVID19_DIAGNOSIS
+    topic: questionnaire_covid19_diagnosis
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/covid19_diagnosis/covid19_diagnosis_armt.json
+  - type: COVID19_SYMPTOMS
+    topic: questionnaire_covid19_symptoms
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/covid19_symptoms/covid19_symptoms_armt.json
+  - type: CNS_COVID19_BASELINE
+    topic: questionnaire_cns_covid19_baseline
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/cns_covid19_baseline/cns_covid19_baseline_armt.json
+  - type: CNS_COVID19_FOLLOWUP
+    topic: questionnaire_cns_covid19_followup
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/cns_covid19_followup/cns_covid19_followup_armt.json
+  - type: CNS_COVID19_FOLLOWUP_V2
+    topic: questionnaire_cns_covid19_followup_v2
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/cns_covid19_followup_v2/cns_covid19_followup_v2_armt.json
+  - type: CNS_COVID19_FOLLOWUP_V3
+    topic: questionnaire_cns_covid19_followup_v3
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/cns_covid19_followup_v3/cns_covid19_followup_v3_armt.json
+  - type: ART_COVID19_FOLLOWUP
+    topic: questionnaire_art_covid19_followup
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/art_covid19_followup/art_covid19_followup_armt.json
+  - type: ADHD_MEDICATION_USE
+    topic: questionnaire_adhd_medication_use
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/adhd_medication_use/adhd_medication_use_armt.json
+  - type: QIDS
+    topic: questionnaire_qids
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/qids/qids_armt.json
+  - type: WSAS
+    topic: questionnaire_wsas
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/wsas/wsas_armt.json
+  - type: SLEEP_QUESTIONS
+    topic: questionnaire_rapid_sleep_questions
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/sleep_questions/sleep_questions_armt.json
+  - type: AUDIO_WITHOUT_UNSCRIPTED
+    doc: A speech questionnaire similar to the AUDIO questionnaire but without the second unscripted task.
+    topic: questionnaire_audio_without_unscripted
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/audio_without_unscripted/audio_without_unscripted_armt.json
+  - type: AUDIO_WITHOUT_UNSCRIPTED_2
+    doc: A speech questionnaire similar to the AUDIO questionnaire but without the second unscripted task.
+    topic: questionnaire_audio_without_unscripted_2
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/audio_without_unscripted_2/audio_without_unscripted_armt.json
+  - type: AUDIO_WITHOUT_UNSCRIPTED_3
+    doc: A speech questionnaire similar to the AUDIO questionnaire but without the second unscripted task.
+    topic: questionnaire_audio_without_unscripted_3
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/audio_without_unscripted_3/audio_without_unscripted_armt.json
+  - type: CAT
+    topic: questionnaire_cat
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/cat/cat_armt.json
+  - type: PSQI
+    topic: questionnaire_psqi
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/psqi/psqi_armt.json
+  - type: FSS
+    topic: questionnaire_fss
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/fss/fss_armt.json
+  - type: PCFS
+    topic: questionnaire_pcfs
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/pcfs/pcfs_armt.json
+  - type: RALPMH_COVID_SYMPTOMS
+    topic: questionnaire_ralpmh_covid_symptoms
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/ralpmh_covid_symptoms/ralpmh_covid_symptoms_armt.json
+  - type: LIPF
+    topic: questionnaire_lipf
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/lipf/lipf_armt.json
+  - type: ERS
+    topic: questionnaire_ers
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/ers/ers_armt.json
+  - type: VAS
+    topic: questionnaire_vas
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/vas/vas_armt.json
+  - type: PULSE_OX
+    topic: questionnaire_pulse_ox
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/pulse_ox/pulse_ox_armt.json
+  - type: AUDIO_WITHOUT_UNSCRIPTED_4
+    doc: A speech questionnaire that contains `The North Wind` scripted text where users will record themselves reading a text aloud.
+    topic: questionnaire_audio_without_unscripted_4
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/audio_without_unscripted_4/audio_without_unscripted_4_armt.json
+  - type: AUDIO_COUNT
+    doc: A speech questionnaire where users will record themselves count from 1 to 20 aloud.
+    topic: questionnaire_audio_count
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/audio_count/audio_count_armt.json
+  - type: AUDIO_VOCALISATION
+    doc: A speech questionnaire where users will record themselves speak the vowels displayed on the screen aloud.
+    topic: questionnaire_audio_vocalisation
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/audio_vocalisation/audio_vocalisation_armt.json
+  - type: EXACERBATION_DIARY
+    topic: questionnaire_exacerbation_diary
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/exacerbation_diary/exacerbation_diary_armt.json
+  - type: NUVOAIR_SPIROMETRY
+    topic: notification_nuvoair_spirometry
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/nuvoair_spirometry/nuvoair_spirometry_armt.json
+  - type: K_BUILD_PRIVATE
+    topic: questionnaire_k_build_private
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions-Private/master/questionnaires/k_build_private/k_build_private_armt.json
+  - type: EPI_SEIZURE_DIARY
+    topic: questionnaire_epi_seizure_diary
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/epi_seizure_diary/epi_seizure_diary_armt.json
+  - type: EPI_EVENING_QUESTIONNAIRE
+    topic: questionnaire_epi_evening_questionnaire
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/epi_evening_questionnaire/epi_evening_questionnaire_armt.json
+  - type: EPI_WSAS
+    topic: questionnaire_epi_wsas
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/epi_wsas/epi_wsas_armt.json
+  - type: BP
+    topic: questionnaire_bp
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/bp/bp_armt.json
+  - type: HLH
+    topic: questionnaire_hlh
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/hlh/hlh_armt.json
+  - type: TECHNOLOGY_USAGE
+    topic: questionnaire_technology_usage
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/technology_usage/technology_usage_armt.json
+  - type: REGULAR_ACTIVITIES
+    topic: questionnaire_regular_activities
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/regular_activities/regular_activities_armt.json
+  - type: NONREGULAR_ACTIVITIES
+    topic: questionnaire_nonregular_activities
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/nonregular_activities/nonregular_activities_armt.json
+  - type: AUTISM_SYMPTOMS
+    topic: questionnaire_autism_symptoms
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/autism_symptoms/autism_symptoms_armt.json
+  - type: SLEEP_QUALITY_INFO
+    topic: questionnaire_sleep_quality
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/sleep_quality_info/sleep_quality_info_armt.json
+  - type: SLEEP_QUALITY
+    topic: questionnaire_sleep_quality
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/sleep_quality/sleep_quality_armt.json
+  - type: ADHD_SYMPTOMS
+    topic: questionnaire_adhd_symptoms
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/adhd_symptoms/adhd_symptoms_armt.json
+  - type: USER_FEEDBACK
+    topic: questionnaire_user_feedback
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/user_feedback/user_feedback_armt.json
+  - type: PROGRESS_REPORT_1
+    topic: questionnaire_progress_report
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/progress_report_1/progress_report_1_armt.json
+  - type: PROGRESS_REPORT_2
+    topic: questionnaire_progress_report
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/progress_report_2/progress_report_2_armt.json
+  - type: PROGRESS_REPORT_3
+    topic: questionnaire_progress_report
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/progress_report_3/progress_report_3_armt.json
+  - type: PROGRESS_REPORT_4
+    topic: questionnaire_progress_report
+    value_schema: .active.questionnaire.Questionnaire
+    questionnaire_definition_url: https://raw.githubusercontent.com/RADAR-base/RADAR-REDCap-aRMT-Definitions/master/questionnaires/progress_report_4/progress_report_4_armt.json


### PR DESCRIPTION
Adds a general `questionnaire_response` Kafka topic to the aRMT app, as well as moving the monitoring topics to that general device type. This allows an installation to have far fewer topics if the users do not require questionnaire responses to be separated over different topics. For example in Confluent Cloud this makes a big cost difference.

