### PR TITLE
Fix Healthkit schema

### DIFF
--- a/commons/active/healthkit/healthkit_typed_data.avsc
+++ b/commons/active/healthkit/healthkit_typed_data.avsc
@@ -5,7 +5,7 @@
   "doc": "HealthKit generic typed data schema.",
   "fields": [
     {
-      "name": "startTime",
+      "name": "time",
       "type": "double",
       "doc": "Start time of this activity period in UTC (s)."
     },


### PR DESCRIPTION
- Update `time` field in Healthkit generic schema (change `startTime` to `time`) to fix issues with the filename in output restructure