### PR TITLE
Added Schemas for Google Activity Recognition API

### DIFF
--- a/commons/passive/google/google_activity_transition_event.avsc
+++ b/commons/passive/google/google_activity_transition_event.avsc
@@ -1,0 +1,22 @@
+{
+  "namespace": "org.radarcns.passive.google",
+  "type": "record",
+  "name": "GoogleActivityTransitionEvent",
+  "doc": "Represents an activity transition event, for example start to walk, stop running etc.",
+  "fields": [
+    { "name": "time", "type": "double", "doc": "Device timestamp in UTC (s)." },
+    { "name": "timeReceived", "type": "double", "doc": "Device receiver timestamp in UTC (s)." },
+    { "name": "activity", "type": {
+      "name": "ActivityType",
+      "type": "enum",
+      "doc": "The detected activity of the device. \nIN_VEHICLE indicates the device is in a vehicle, such as a car. \nON_BICYCLE indicates the device is on a bicycle. \n ON_FOOT indicates the device is on a user who is walking or running. \nRUNNING indicates the device is on a user who is running. This is a sub-activity of ON_FOOT. \nSTILL indicates the device is still (not moving). \nTILTING indicates the device angle relative to gravity changed significantly. This often occurs when a device is picked up from a desk or a user who is sitting stands up. \nWALKING indicates the device is on a user who is walking. This is a sub-activity of ON_FOOT. \nUNKNOWN indicates Unable to detect the current activity.",
+      "symbols": ["IN_VEHICLE", "ON_BICYCLE", "ON_FOOT", "RUNNING", "STILL", "TILTING", "WALKING", "UNKNOWN"]
+    }, "doc": "Gets the type of the activity of the transition.", "default": "UNKNOWN" },
+    { "name": "transition", "type": {
+      "name": "TransitionType",
+      "type": "enum",
+      "doc": "Represents the transition associated with an activity listed in ActivityType. For instance start to walk, stop running etc. \nENTER represents user enters the given activity from ActivityType. \nEXIT represents user exits the given activity from ActivityType.",
+      "symbols": ["ENTER", "EXIT", "UNKNOWN"]
+    }, "doc": "Represents the transition associated with an activity listed in ActivityType.", "default": "UNKNOWN" }
+  ]
+}

--- a/specifications/passive/android_google-1.0.0.yml
+++ b/specifications/passive/android_google-1.0.0.yml
@@ -21,3 +21,12 @@ data:
     sample_rate:
       interval: 600
       dynamic: true
+  #Google Activity Recognition
+  - type: ACTIVITY_TRANSITION_EVENT
+    app_provider: .google.GoogleActivityProvider
+    unit: NON_DIMENSIONAL
+    processing_state: RAW
+    topic: android_google_activity_transition_event
+    value_schema: .passive.google.GoogleActivityTransitionEvent
+    sample_rate:
+      dynamic: true


### PR DESCRIPTION
Changes:

- [ Added `google_activity_recognition_event` schema. ] 
- [ Updated specification `android_google_1.0.0`, included specifications for activity_transition_events. ]

Fixes issue https://github.com/RADAR-base/RADAR-Schemas/issues/337