### PR TITLE
removed unsupported activity types from activity transition event

### DIFF
--- a/commons/passive/google/google_activity_transition_event.avsc
+++ b/commons/passive/google/google_activity_transition_event.avsc
@@ -9,8 +9,8 @@
     { "name": "activity", "type": {
       "name": "ActivityType",
       "type": "enum",
-      "doc": "The detected activity of the device. \nIN_VEHICLE indicates the device is in a vehicle, such as a car. \nON_BICYCLE indicates the device is on a bicycle. \n ON_FOOT indicates the device is on a user who is walking or running. \nRUNNING indicates the device is on a user who is running. This is a sub-activity of ON_FOOT. \nSTILL indicates the device is still (not moving). \nTILTING indicates the device angle relative to gravity changed significantly. This often occurs when a device is picked up from a desk or a user who is sitting stands up. \nWALKING indicates the device is on a user who is walking. This is a sub-activity of ON_FOOT. \nUNKNOWN indicates activity is not detected.",
-      "symbols": ["IN_VEHICLE", "ON_BICYCLE", "ON_FOOT", "RUNNING", "STILL", "TILTING", "WALKING", "UNKNOWN"]
+      "doc": "The detected activity of the device. \nIN_VEHICLE indicates the device is in a vehicle, such as a car. \nON_BICYCLE indicates the device is on a bicycle. \n ON_FOOT indicates the device is on a user who is walking or running. \nRUNNING indicates the device is on a user who is running. This is a sub-activity of ON_FOOT. \nSTILL indicates the device is still (not moving). \nWALKING indicates the device is on a user who is walking. This is a sub-activity of ON_FOOT.",
+      "symbols": ["IN_VEHICLE", "ON_BICYCLE", "ON_FOOT", "RUNNING", "STILL", "WALKING", "UNKNOWN"]
     }, "doc": "Gets the type of the activity of the transition.", "default": "UNKNOWN" },
     { "name": "transition", "type": {
       "name": "TransitionType",


### PR DESCRIPTION
During the testing of the activity transition plugin, events for `TILTING` and `UNKNOWN` are not supported. The plugin throws an exception with the message `ActivityTransitionRequest specified an unsupported transition activity type`.