### PR TITLE
Using PairState enum for paired status of remote bluetooth device.

### DIFF
--- a/commons/passive/phone/phone_bluetooth_device_scanned.avsc
+++ b/commons/passive/phone/phone_bluetooth_device_scanned.avsc
@@ -8,11 +8,12 @@
     {"name": "timeReceived", "type": "double", "doc": "Device receiver timestamp in UTC (s)."},
     {"name": "macAddressHash", "type": ["null", "bytes"], "default": null, "doc":"Hash of Nearby Bluetooth device MAC address."},
     {"name": "hashSaltReference", "type": ["null", "int"], "doc": "Random identifier associated with the device or installation of the app. If the app gets reinstalled or installed on another device, it's clear during analysis that the mac addresses between iterations are not comparable.", "default": null},
+    {"name": "isPaired", "type": ["null","boolean"], "doc": "Whether the bluetooth device is paired. This has been deprecated in favor of pairedState in newer versions.", "default": null},
     {"name": "pairedState", "type": ["null", {
       "name": "PairedState",
       "type": "enum",
-      "doc": "Represent the bond state of the remote device. \nNOT_PAIRED indicates the remote device is not paired. \nPAIRING indicates pairing is in progress with the remote device. \nPAIRED Indicates the remote device is paired.",
-      "symbols": ["NOT_PAIRED", "PAIRING", "PAIRED"]
+      "doc": "Represent the bond state of the remote device. \nNOT_PAIRED indicates the remote device is not paired. \nPAIRING indicates pairing is in progress with the remote device. \nPAIRED Indicates the remote device is paired. \nUNKNOWN indicates the pairing status is not known.",
+      "symbols": ["NOT_PAIRED", "PAIRING", "PAIRED", "UNKNOWN"]
     }], "doc": "Indicates the current paired status of the remote device.", "default": null }
   ]
 }

--- a/commons/passive/phone/phone_bluetooth_device_scanned.avsc
+++ b/commons/passive/phone/phone_bluetooth_device_scanned.avsc
@@ -8,6 +8,11 @@
     {"name": "timeReceived", "type": "double", "doc": "Device receiver timestamp in UTC (s)."},
     {"name": "macAddressHash", "type": ["null", "bytes"], "default": null, "doc":"Hash of Nearby Bluetooth device MAC address."},
     {"name": "hashSaltReference", "type": ["null", "int"], "doc": "Random identifier associated with the device or installation of the app. If the app gets reinstalled or installed on another device, it's clear during analysis that the mac addresses between iterations are not comparable.", "default": null},
-    {"name": "isPaired", "type": ["null","boolean"], "doc": "Whether the bluetooth device is paired.", "default": null}
+    {"name": "pairedState", "type": ["null", {
+      "name": "PairedState",
+      "type": "enum",
+      "doc": "Represent the bond state of the remote device. \nNOT_PAIRED indicates the remote device is not paired. \nPAIRING indicates pairing is in progress with the remote device. \nPAIRED Indicates the remote device is paired.",
+      "symbols": ["NOT_PAIRED", "PAIRING", "PAIRED"]
+    }], "doc": "Indicates the current paired status of the remote device", "default": null }
   ]
 }

--- a/commons/passive/phone/phone_bluetooth_device_scanned.avsc
+++ b/commons/passive/phone/phone_bluetooth_device_scanned.avsc
@@ -13,6 +13,6 @@
       "type": "enum",
       "doc": "Represent the bond state of the remote device. \nNOT_PAIRED indicates the remote device is not paired. \nPAIRING indicates pairing is in progress with the remote device. \nPAIRED Indicates the remote device is paired.",
       "symbols": ["NOT_PAIRED", "PAIRING", "PAIRED"]
-    }], "doc": "Indicates the current paired status of the remote device", "default": null }
+    }], "doc": "Indicates the current paired status of the remote device.", "default": null }
   ]
 }


### PR DESCRIPTION
Earlier the pairing state of the remote device is calculated manually, but there is also a straightforward and precise way [here](https://developer.android.com/reference/android/bluetooth/BluetoothDevice#getBondState()).