### PR TITLE
Fix basic authentication during schema registry init

### DIFF
--- a/java-sdk/radar-schemas-registration/src/main/java/org/radarbase/schema/registration/SchemaRegistry.kt
+++ b/java-sdk/radar-schemas-registration/src/main/java/org/radarbase/schema/registration/SchemaRegistry.kt
@@ -18,8 +18,7 @@ package org.radarbase.schema.registration
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BasicAuthCredentials
 import io.ktor.client.plugins.auth.providers.basic
-import io.ktor.client.request.setBody
-import io.ktor.client.request.url
+import io.ktor.client.request.*
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.contentType
@@ -56,8 +55,8 @@ import kotlin.time.toKotlinDuration
  */
 class SchemaRegistry(
     private val baseUrl: String,
-    apiKey: String? = null,
-    apiSecret: String? = null,
+    private val apiKey: String? = null,
+    private val apiSecret: String? = null,
     private val topicConfiguration: Map<String, TopicConfig> = emptyMap(),
 ) {
     private val schemaClient: SchemaRetriever = schemaRetriever(baseUrl) {
@@ -66,6 +65,7 @@ class SchemaRegistry(
             if (apiKey != null && apiSecret != null) {
                 install(Auth) {
                     basic {
+                        sendWithoutRequest { true }
                         credentials {
                             BasicAuthCredentials(username = apiKey, password = apiSecret)
                         }
@@ -93,6 +93,9 @@ class SchemaRegistry(
                     try {
                         httpClient.request<List<String>> {
                             url("subjects")
+                            if (apiKey != null && apiSecret != null) {
+                                basicAuth(apiKey, apiSecret)
+                            }
                         }
                     } catch (ex: RestException) {
                         logger.error(

--- a/java-sdk/radar-schemas-registration/src/main/java/org/radarbase/schema/registration/SchemaRegistry.kt
+++ b/java-sdk/radar-schemas-registration/src/main/java/org/radarbase/schema/registration/SchemaRegistry.kt
@@ -19,8 +19,8 @@ import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BasicAuthCredentials
 import io.ktor.client.plugins.auth.providers.basic
 import io.ktor.client.request.basicAuth
-import io.ktor.client.request.url
 import io.ktor.client.request.setBody
+import io.ktor.client.request.url
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.contentType

--- a/java-sdk/radar-schemas-registration/src/main/java/org/radarbase/schema/registration/SchemaRegistry.kt
+++ b/java-sdk/radar-schemas-registration/src/main/java/org/radarbase/schema/registration/SchemaRegistry.kt
@@ -18,7 +18,9 @@ package org.radarbase.schema.registration
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BasicAuthCredentials
 import io.ktor.client.plugins.auth.providers.basic
-import io.ktor.client.request.*
+import io.ktor.client.request.basicAuth
+import io.ktor.client.request.url
+import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.contentType
@@ -178,6 +180,7 @@ class SchemaRegistry(
                 val record: SpecificRecord = AvroTopic.parseSpecificRecord(topicValueSchema)
                 record.javaClass to record.schema
             }
+
             defaultTopic != null -> defaultTopic.valueClass to defaultTopic.valueSchema
             else -> {
                 logger.warn(


### PR DESCRIPTION
# Problem

During initialization of schema registry the following error was thrown:

```
[2024-03-19 17:47:28,574] INFO  - Initializing SchemaRegistration with authentication... (SchemaRegistryCommand.kt:98)
[2024-03-19 17:47:29,631] ERROR - Schema registry https://psrc-4kk0p.westeurope.azure.confluent.cloud not ready, responded with HTTP 401 Unauthorized: REST call to <https://psrc-4kk0p.westeurope.azure.confluent.cloud/subjects> failed (HTTP code 401 Unauthorized): {"error_code":401,"message":"Unauthorized"} (Emitters.kt:231)
[2024-03-19 17:47:29,633] INFO  - Waiting 1.321031400s seconds to retry (KafkaTopics.kt:303)
```

The cause was that basic authentication headers were not sent during init where the schema registry requests the `/subjects` endpoint.


# Solution

A basic auth header was added so that the request succeeds.


# Note

Basic auth headers appeared to be set at a global scale for the Ktor HttpClient. However, these do not appear to work for the `/subjects` call during init. To make sure we do not run into problems elsewhere I added the `sendWithoutRequest ` param to the global HttpClient config (see [docs](https://ktor.io/docs/basic-client.html#configure)).