### PR TITLE
Correct docs on Confluent Cloud deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,14 +156,16 @@ docker-compose run --rm tools radar-schemas-tools schema-topic --ensure -f schem
       sasl.mechanism: PLAIN
     ```
 
-    1.2. Run `topic-create` command
+    1.2. Run `create` command
 
     ```
-    docker run --rm -v "$PWD/config.yaml:/etc/radar-schemas-tools/config.yaml" radarbase/radar-schemas-tools radar-schemas-tools topic-create -c /etc/radar-schemas-tools/config.yaml /schema/merged
+    docker run --rm -v "$PWD/config.yaml:/etc/radar-schemas-tools/config.yaml" radarbase/radar-schemas-tools radar-schemas-tools create -c /etc/radar-schemas-tools/config.yaml /schema/merged
     ```
 
 2. Register schemas on Confluent Cloud schema registry
 
     ```
-    docker run --rm radarbase/kafka-init radar-schemas-tools register SR_ENDPOINT -u SR_API_KEY -p SR_API_SECRET /schema/merged
+    docker run --rm -v "$PWD/config.yaml:/etc/radar-schemas-tools/config.yaml" radarbase/radar-schemas-tools radar-schemas-tools register -c /etc/radar-schemas-tools/config.yaml -u SR_API_KEY -p SR_API_SECRET SR_ENDPOINT /schema/merged
     ```
+   
+   Note that the `SR_ENDPOINT` and `/schema/merged` are positional arguments and should be placed at the end of the command.


### PR DESCRIPTION
It appears that the documents on Confluent Cloud deployment of schemas were not fully updated to reflect the new _radar-schema-tools_ docker image. This PR corrects this.