### PR TITLE
Fix schemaregistry

### DIFF
--- a/java-sdk/build.gradle.kts
+++ b/java-sdk/build.gradle.kts
@@ -23,6 +23,12 @@ val githubIssueUrl = "https://github.com/$githubRepoName/issues"
 subprojects {
     apply(plugin = "org.radarbase.radar-kotlin")
 
+    repositories{
+        mavenCentral()
+        gradlePluginPortal()
+        maven(url = "https://jitpack.io")
+    }
+
     radarKotlin {
         javaVersion.set(Versions.java)
         kotlinVersion.set(Versions.kotlin)
@@ -64,9 +70,9 @@ configure(listOf(
         githubUrl.set("https://github.com/$githubRepoName")
         developers {
             developer {
-                id.set("blootsvoets")
-                name.set("Joris Borgdorff")
-                email.set("joris@thehyve.nl")
+                id.set("bdegraaf1234")
+                name.set("Bastiaan de Graaf")
+                email.set("bastiaan@thehyve.nl")
                 organization.set("The Hyve")
             }
             developer {

--- a/java-sdk/buildSrc/src/main/kotlin/Versions.kt
+++ b/java-sdk/buildSrc/src/main/kotlin/Versions.kt
@@ -5,7 +5,7 @@ object Versions {
     const val java = 17
     const val avroGenerator = "1.9.1"
 
-    const val radarCommons = "1.1.2"
+    const val radarCommons = "1.1.3-SNAPSHOT"
     const val avro = "1.11.3"
     const val jackson = "2.16.1"
     const val argparse = "0.9.0"

--- a/java-sdk/radar-schemas-registration/build.gradle.kts
+++ b/java-sdk/radar-schemas-registration/build.gradle.kts
@@ -1,9 +1,5 @@
 description = "RADAR Schemas specification and validation tools"
 
-repositories {
-    maven(url = "https://jitpack.io")
-}
-
 dependencies {
     api(project(":radar-schemas-commons"))
     api(project(":radar-schemas-core"))

--- a/java-sdk/radar-schemas-tools/build.gradle.kts
+++ b/java-sdk/radar-schemas-tools/build.gradle.kts
@@ -1,9 +1,5 @@
 description = "RADAR Schemas specification and validation tools."
 
-repositories {
-    maven(url = "https://jitpack.io")
-}
-
 dependencies {
     implementation(project(":radar-schemas-registration"))
     implementation(platform("com.fasterxml.jackson:jackson-bom:${Versions.jackson}"))


### PR DESCRIPTION
Issues with basic authentication (see #368)

It seems that httpclient configuration was not properly passed to the `SchemaRegistry`

This PR is dependent on a new release of radar-commons