### PR TITLE
Add support for Sentry monitoring

### DIFF
--- a/java-sdk/radar-catalog-server/README.md
+++ b/java-sdk/radar-catalog-server/README.md
@@ -1,0 +1,9 @@
+# RADAR Catalog Server
+
+## Sentry monitoring
+
+To enable Sentry monitoring:
+
+1. Set a `SENTRY_DSN` environment variable that points to the desired Sentry DSN.
+2. (Optional) Set the `SENTRY_LOG_LEVEL` environment variable to control the minimum log level of events sent to Sentry.
+   The default log level for Sentry is `WARN`. Possible values are `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR`.

--- a/java-sdk/radar-catalog-server/build.gradle.kts
+++ b/java-sdk/radar-catalog-server/build.gradle.kts
@@ -1,3 +1,9 @@
+plugins {
+    // TODO Remove this when new release of radar-commons is available and used in this project.
+    // This version has Sentry support built in for radar-kotlin plugin.
+    id("io.sentry.jvm.gradle") version "4.11.0"
+}
+
 description = "RADAR Schemas specification and validation tools."
 
 dependencies {

--- a/java-sdk/radar-catalog-server/src/main/resources/log4j2.xml
+++ b/java-sdk/radar-catalog-server/src/main/resources/log4j2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ /*
+  ~  *  Copyright 2024 The Hyve
+  ~  *
+  ~  *  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  *  you may not use this file except in compliance with the License.
+  ~  *  You may obtain a copy of the License at
+  ~  *
+  ~  *    http://www.apache.org/licenses/LICENSE-2.0
+  ~  *
+  ~  *  Unless required by applicable law or agreed to in writing, software
+  ~  *  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  *  See the License for the specific language governing permissions and
+  ~  *  limitations under the License.
+  ~  */
+  -->
+
+<configuration status="INFO">
+    <appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout
+                    pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+            />
+        </Console>
+        <!-- For Sentry to work the DSN must be set via SENTRY_DSN environment variable
+             When SENTRY_DSN is empty string, the Sentry SDK is disabled -->
+        <Sentry name="Sentry" debug="false"/>
+    </appenders>
+
+    <loggers>
+        <root level="INFO">
+            <appender-ref ref="Console" />
+            <!-- Note that the Sentry logging threshold is at WARN level by default -->
+            <appender-ref ref="Sentry" level="${env:SENTRY_LOG_LEVEL:-WARN}" />
+        </root>
+    </loggers>
+</configuration>


### PR DESCRIPTION
Description: This PR will add option to monitor the application with Sentry. Sentry monitoring will be enabled by the following:

1. Set a `SENTRY_DSN` environment variable that points to the desired Sentry DSN.
2. (Optional) Set the `SENTRY_LOG_LEVEL` environment variable to control the minimum log level of events sent to Sentry.
   The default log level for Sentry is `WARN`. Possible values are `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR`.

The docs were updated with these instructions.