### PR TITLE
Added schemas and specifications for collecting application metrics 

### DIFF
--- a/commons/monitor/application/application_network_status.avsc
+++ b/commons/monitor/application/application_network_status.avsc
@@ -5,9 +5,9 @@
     "doc": "Represents the network connectivity status of an application, indicating whether it is connected to the internet and, if so, whether the connection is via Wi-Fi or cellular data. Data for this topic is not transmitted automatically; it is sent only after the user explicitly submits the metrics following their review in the application.",
     "fields": [
         {"name": "time", "type": "double", "doc": "Timestamp of the event recorded on the device, in UTC seconds."},
-        {"name": "connectionState",
+        {"name": "connectionStatus",
             "type": {
-                "name": "connectionState",
+                "name": "ConnectionStatus",
                 "type": "enum",
                 "doc": "Represents the application's network connectivity status.",
                 "symbols": [

--- a/commons/monitor/application/application_network_status.avsc
+++ b/commons/monitor/application/application_network_status.avsc
@@ -1,0 +1,24 @@
+{
+    "namespace": "org.radarcns.monitor.application",
+    "type": "record",
+    "name": "ApplicationNetworkStatus",
+    "doc": "Represents the network connectivity status of an application, indicating whether it is connected to the internet and, if so, whether the connection is via Wi-Fi or cellular data. Data for this topic is not transmitted automatically; it is sent only after the user explicitly submits the metrics following their review in the application.",
+    "fields": [
+        {"name": "time", "type": "double", "doc": "Timestamp of the event recorded on the device, in UTC seconds."},
+        {"name": "connectionState",
+            "type": {
+                "name": "connectionState",
+                "type": "enum",
+                "doc": "Represents the application's network connectivity status.",
+                "symbols": [
+                    "DISCONNECTED",
+                    "CONNECTED_WIFI",
+                    "CONNECTED_CELLULAR",
+                    "UNKNOWN"
+                ]
+            },
+            "doc": "Current network connectivity state of the application. It indicates whether the application is disconnected, connected via Wi-Fi, connected via cellular data, or in an unknown state.",
+            "default": "UNKNOWN"
+        }
+    ]
+}

--- a/commons/monitor/application/application_plugin_status.avsc
+++ b/commons/monitor/application/application_plugin_status.avsc
@@ -8,7 +8,7 @@
         {"name": "pluginName", "type": "string", "doc": "Name of the plugin for which status information is provided."},
         {"name": "sourceStatus",
             "type": {
-                "name": "sourceStatus",
+                "name": "SourceStatus",
                 "type": "enum",
                 "doc": "Represents the current connection state of the plugin.",
                 "symbols": [

--- a/commons/monitor/application/application_plugin_status.avsc
+++ b/commons/monitor/application/application_plugin_status.avsc
@@ -1,0 +1,28 @@
+{
+    "namespace": "org.radarcns.monitor.application",
+    "type": "record",
+    "name": "ApplicationPluginStatus",
+    "doc": "Represents the status of a plugin, indicating its current connection state. Data for this topic is not transmitted automatically; it is sent only after the user explicitly submits the metrics following their review in the application.",
+    "fields": [
+        {"name": "time", "type": "double", "doc": "Timestamp of the event recorded on the device, in UTC seconds."},
+        {"name": "pluginName", "type": "string", "doc": "Name of the plugin for which status information is provided."},
+        {"name": "sourceStatus",
+            "type": {
+                "name": "sourceStatus",
+                "type": "enum",
+                "doc": "Represents the current connection state of the plugin.",
+                "symbols": [
+                    "READY",
+                    "CONNECTING",
+                    "CONNECTED",
+                    "DISCONNECTING",
+                    "DISCONNECTED",
+                    "UNAVAILABLE",
+                    "UNKNOWN"
+                ]
+            },
+            "doc": "Current status of the plugin. The meanings of each status are as follows:\n- READY: The source manager is scanning for compatible sources.\n- CONNECTING: A source has been found and the source manager is attempting to connect, but no data has been received yet.\n- CONNECTED: A compatible source has been found and connected, allowing data to stream in.\n- DISCONNECTING: A source is in the process of disconnecting and may still stream data.\n- DISCONNECTED: A source has been disconnected and will no longer stream data. If this status is passed without an argument, it indicates that the source manager is no longer active.\n- UNAVAILABLE: The source cannot be started because certain initial conditions are not met.",
+            "default": "UNKNOWN"
+        }
+    ]
+}

--- a/commons/monitor/application/application_topic_records_sent.avsc
+++ b/commons/monitor/application/application_topic_records_sent.avsc
@@ -1,0 +1,15 @@
+{
+    "namespace": "org.radarcns.monitor.application",
+    "type": "record",
+    "name": "ApplicationTopicRecordsSent",
+    "doc": "Represents the number of records sent for a Kafka topic since the last update.",
+    "fields": [
+        {"name": "time", "type": "double", "doc": "Device timestamp in UTC seconds."},
+        {"name": "topicName", "type": ["null", "string"], "doc": "Name of the Kafka topic for which record information is provided.", "default": null},
+        {
+            "name": "recordsSent",
+            "type": "long",
+            "doc": "Number of records sent for the topic since the last report. For example, if a total of 20,000 records have been sent overall, and last call reported 15000 topics then the most recent report indicates that 5,000 records were sent since the previous upload."
+        }
+    ]
+}

--- a/specifications/monitor/radar_prmt-1.1.0.yml
+++ b/specifications/monitor/radar_prmt-1.1.0.yml
@@ -50,3 +50,23 @@ data:
       configurable: true
     topic: application_device_info
     value_schema: .monitor.application.ApplicationDeviceInfo
+  - type: PLUGIN_STATUS
+    doc: Status of each plugin running in application
+    sample_rate:
+      dynamic: true
+    topic: application_plugin_status
+    value_schema: .monitor.application.ApplicationPluginStatus
+  - type: NETWORK_STATUS
+    doc: Connectivity status of the application
+    sample_rate:
+      dynamic: true
+    topic: application_network_status
+    value_schema: .monitor.application.ApplicationNetworkStatus
+  - type: TOPIC_RECORDS_SENT
+    doc: Number of records sent per topic since the last report
+    sample_rate:
+      interval: 300
+      configurable: true
+    topic: application_topic_records_sent
+    value_schema: .monitor.application.ApplicationTopicRecordsSent
+


### PR DESCRIPTION
Three schemas have been added to collect data on the following:

1. The status of each plugin.
2. The connectivity status of the application.
3. The number of records sent per topic.
