### PR TITLE
Upgrade RADAR-Schemas for Maven central release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,15 +21,15 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Compile code
         run: ./gradlew assemble
@@ -48,7 +48,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Docker build parameters
         id: docker_params
@@ -66,7 +66,7 @@ jobs:
 
       - name: Cache Docker layers
         id: cache_buildx
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ steps.docker_params.outputs.push }}-${{ hashFiles('Dockerfile', 'java-sdk/**/*.gradle', 'java-sdk/gradle.properties', 'java-sdk/*/src/main/**', 'commons/**', 'specifications/**', 'docker/**') }}
@@ -76,7 +76,7 @@ jobs:
 
       - name: Log in to Docker Hub
         if: steps.docker_params.outputs.has_docker_login == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -84,16 +84,16 @@ jobs:
       # Add Docker labels and tags
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKER_IMAGE }}
 
       # Setup docker build environment
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache parameters
         id: cache-parameters
@@ -105,7 +105,7 @@ jobs:
           fi
 
       - name: Build docker
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/publish_snapshots.yml
+++ b/.github/workflows/publish_snapshots.yml
@@ -19,19 +19,19 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Has SNAPSHOT version
         id: is-snapshot
         run: grep 'const val project = ".*-SNAPSHOT"' buildSrc/src/main/kotlin/Versions.kt
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
 
       - name: Install gpg secret key
@@ -41,6 +41,6 @@ jobs:
 
       - name: Publish
         env:
-          OSSRH_USER: ${{ secrets.OSSRH_USER }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          OSSRH_USER: ${{ secrets.OSSRH_USER_TOKEN_ID }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_USER_TOKEN_SECRET }}
         run: ./gradlew -Psigning.gnupg.keyName=${{ secrets.OSSRH_GPG_SECRET_KEY_NAME }} -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,22 +17,22 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Compile code
         run: ./gradlew assemble
 
       # Upload it to GitHub
       - name: Upload to GitHub
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@v3.0
         with:
           files: 'java-sdk/*/build/distributions/*;java-sdk/*/build/libs/*.jar'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -44,8 +44,8 @@ jobs:
 
       - name: Publish
         env:
-          OSSRH_USER: ${{ secrets.OSSRH_USER }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          OSSRH_USER: ${{ secrets.OSSRH_USER_TOKEN_ID }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_USER_TOKEN_SECRET }}
         run: ./gradlew -Psigning.gnupg.keyName=${{ secrets.OSSRH_GPG_SECRET_KEY_NAME }} -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} publish closeAndReleaseSonatypeStagingRepository
 
   # Build and push tagged release docker image
@@ -59,11 +59,11 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -71,7 +71,7 @@ jobs:
       # Add Docker labels and tags
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.DOCKER_IMAGE }}
           tags: |
@@ -79,13 +79,13 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
       # Setup docker build environment
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build docker
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           # Allow running the image on X86 and ARM.

--- a/java-sdk/buildSrc/src/main/kotlin/Versions.kt
+++ b/java-sdk/buildSrc/src/main/kotlin/Versions.kt
@@ -5,7 +5,7 @@ object Versions {
     const val java = 17
     const val avroGenerator = "1.9.1"
 
-    const val radarCommons = "1.1.2"
+    const val radarCommons = "1.2.3"
     const val avro = "1.11.4"
     const val jackson = "2.16.1"
     const val argparse = "0.9.0"

--- a/java-sdk/settings.gradle.kts
+++ b/java-sdk/settings.gradle.kts
@@ -10,7 +10,7 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         mavenCentral()
-        maven(url = "https://oss.sonatype.org/content/repositories/snapshots") {
+        maven(url = "https://central.sonatype.com/repository/maven-snapshots/") {
             mavenContent {
                 snapshotsOnly()
             }


### PR DESCRIPTION
- Migrated radar-commons version to [1.2.3 ](https://github.com/RADAR-base/radar-commons/pull/194)
- Bumped GitHub Actions versions