### PR TITLE
release-0.8.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,7 @@ env:
 jobs:
   upload:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    permissions: write-all
 
     defaults:
       run:

--- a/java-sdk/buildSrc/src/main/kotlin/Versions.kt
+++ b/java-sdk/buildSrc/src/main/kotlin/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
-    const val project = "0.8.13"
+    const val project = "0.8.14"
 
     const val kotlin = "1.9.10"
     const val java = 17


### PR DESCRIPTION
The release action that uploads artifacts to maven central of the previous release was broken. This release tries to fix the release.