### PR TITLE
Schemas for New Google Health Data Types

### DIFF
--- a/commons/push/googlehealth/googlehealth_activity_level.avsc
+++ b/commons/push/googlehealth/googlehealth_activity_level.avsc
@@ -1,0 +1,28 @@
+{
+  "namespace": "org.radarcns.push.googlehealth",
+  "type": "record",
+  "name": "GoogleHealthActivityLevel",
+  "doc": "Google Health activity level the user sustained during a time interval.",
+  "fields": [
+    { "name": "time", "type": "double", "doc": "Device timestamp in UTC (s)." },
+    { "name": "timeReceived", "type": "double", "doc": "Time this record was collected by the push endpoint, seconds since the Unix Epoch." },
+    { "name": "timeInterval", "type": "int", "doc": "Chronological window size (s)." },
+    {
+      "name": "level",
+      "type": {
+        "name": "GoogleHealthActivityLevelType",
+        "type": "enum",
+        "symbols": [
+          "SEDENTARY",
+          "LIGHTLY_ACTIVE",
+          "MODERATELY_ACTIVE",
+          "VERY_ACTIVE",
+          "UNKNOWN"
+        ],
+        "doc": "Activity level type as computed by device. UNKNOWN covers Google's ACTIVITY_LEVEL_TYPE_UNSPECIFIED."
+      },
+      "doc": "Activity level type in the given time interval.",
+      "default": "UNKNOWN"
+    }
+  ]
+}

--- a/commons/push/googlehealth/googlehealth_activity_level.avsc
+++ b/commons/push/googlehealth/googlehealth_activity_level.avsc
@@ -2,9 +2,9 @@
   "namespace": "org.radarcns.push.googlehealth",
   "type": "record",
   "name": "GoogleHealthActivityLevel",
-  "doc": "Google Health activity level the user sustained during a time interval.",
+  "doc": "Google Health activity level the user sustained during a time interval. Google reports one record for every interval, one minute long in practice, and labels each interval as sedentary, lightly active, moderately active or very active. This is the detailed view of the day. GoogleHealthSedentaryPeriod covers the sedentary time only, and groups neighbouring sedentary minutes together into one longer record.",
   "fields": [
-    { "name": "time", "type": "double", "doc": "Device timestamp in UTC (s)." },
+    { "name": "time", "type": "double", "doc": "Device timestamp in UTC (s). Start of the interval." },
     { "name": "timeReceived", "type": "double", "doc": "Time this record was collected by the push endpoint, seconds since the Unix Epoch." },
     { "name": "timeInterval", "type": "int", "doc": "Chronological window size (s)." },
     {
@@ -17,9 +17,10 @@
           "LIGHTLY_ACTIVE",
           "MODERATELY_ACTIVE",
           "VERY_ACTIVE",
+          "ACTIVITY_LEVEL_TYPE_UNSPECIFIED",
           "UNKNOWN"
         ],
-        "doc": "Activity level type as computed by device. UNKNOWN covers Google's ACTIVITY_LEVEL_TYPE_UNSPECIFIED."
+        "doc": "Activity level type as computed by device. ACTIVITY_LEVEL_TYPE_UNSPECIFIED is Google's own value for an interval it did not classify. UNKNOWN covers any other value Google may report that is not read here yet."
       },
       "doc": "Activity level type in the given time interval.",
       "default": "UNKNOWN"

--- a/commons/push/googlehealth/googlehealth_floors.avsc
+++ b/commons/push/googlehealth/googlehealth_floors.avsc
@@ -1,0 +1,12 @@
+{
+  "namespace": "org.radarcns.push.googlehealth",
+  "type": "record",
+  "name": "GoogleHealthFloors",
+  "doc": "Google Health gained elevation measured in floors over the time interval.",
+  "fields": [
+    { "name": "time", "type": "double", "doc": "Device timestamp in UTC (s)." },
+    { "name": "timeReceived", "type": "double", "doc": "Time this record was collected by the push endpoint, seconds since the Unix Epoch." },
+    { "name": "timeInterval", "type": "int", "doc": "Chronological window size (s)." },
+    { "name": "floors", "type": "int", "doc": "Number of floors gained in this period." }
+  ]
+}

--- a/commons/push/googlehealth/googlehealth_floors.avsc
+++ b/commons/push/googlehealth/googlehealth_floors.avsc
@@ -4,9 +4,9 @@
   "name": "GoogleHealthFloors",
   "doc": "Google Health gained elevation measured in floors over the time interval.",
   "fields": [
-    { "name": "time", "type": "double", "doc": "Device timestamp in UTC (s)." },
+    { "name": "time", "type": "double", "doc": "Device timestamp in UTC (s). Start of the interval the floors were gained in." },
+    { "name": "endTime", "type": "double", "doc": "End of the interval the floors were gained in, seconds since the Unix Epoch (s)." },
     { "name": "timeReceived", "type": "double", "doc": "Time this record was collected by the push endpoint, seconds since the Unix Epoch." },
-    { "name": "timeInterval", "type": "int", "doc": "Chronological window size (s)." },
     { "name": "floors", "type": "int", "doc": "Number of floors gained in this period." }
   ]
 }

--- a/commons/push/googlehealth/googlehealth_sedentary_period.avsc
+++ b/commons/push/googlehealth/googlehealth_sedentary_period.avsc
@@ -1,0 +1,11 @@
+{
+  "namespace": "org.radarcns.push.googlehealth",
+  "type": "record",
+  "name": "GoogleHealthSedentaryPeriod",
+  "doc": "Google Health period during which the user was sedentary, i.e. not moving while wearing the device. The interval is the whole observation, Google reports no further fields for this type.",
+  "fields": [
+    { "name": "time", "type": "double", "doc": "Device timestamp in UTC (s). Start of the sedentary period." },
+    { "name": "timeReceived", "type": "double", "doc": "Time this record was collected by the push endpoint, seconds since the Unix Epoch." },
+    { "name": "timeInterval", "type": "int", "doc": "Chronological window size (s). Duration the user was sedentary." }
+  ]
+}

--- a/commons/push/googlehealth/googlehealth_sedentary_period.avsc
+++ b/commons/push/googlehealth/googlehealth_sedentary_period.avsc
@@ -2,10 +2,10 @@
   "namespace": "org.radarcns.push.googlehealth",
   "type": "record",
   "name": "GoogleHealthSedentaryPeriod",
-  "doc": "Google Health period during which the user was sedentary, i.e. not moving while wearing the device. The interval is the whole observation, Google reports no further fields for this type.",
+  "doc": "Google Health period during which the user was sedentary, i.e. not moving while wearing the device. Google groups each unbroken run of sedentary time into one record, so a period lasts as long as the user stayed still and can run from a few minutes to a few hours. Only sedentary time is reported here, so the periods leave gaps over the rest of the day. GoogleHealthActivityLevel is the detailed view of the same signal, with one record per minute covering the whole day. The interval is the whole observation, Google reports no further fields for this type.",
   "fields": [
     { "name": "time", "type": "double", "doc": "Device timestamp in UTC (s). Start of the sedentary period." },
-    { "name": "timeReceived", "type": "double", "doc": "Time this record was collected by the push endpoint, seconds since the Unix Epoch." },
-    { "name": "timeInterval", "type": "int", "doc": "Chronological window size (s). Duration the user was sedentary." }
+    { "name": "endTime", "type": "double", "doc": "End of the sedentary period, seconds since the Unix Epoch (s)." },
+    { "name": "timeReceived", "type": "double", "doc": "Time this record was collected by the push endpoint, seconds since the Unix Epoch." }
   ]
 }

--- a/specifications/push/radar-googlehealth-push-1.0.0.yml
+++ b/specifications/push/radar-googlehealth-push-1.0.0.yml
@@ -7,6 +7,15 @@ data:
   - doc: The `steps` data type (Interval). Step count per device-reported interval.
     topic: push_googlehealth_steps
     value_schema: .push.googlehealth.GoogleHealthSteps
+  - doc: The `floors` data type (Interval). Elevation gained, in floors, per device-reported interval.
+    topic: push_googlehealth_floors
+    value_schema: .push.googlehealth.GoogleHealthFloors
+  - doc: The `sedentary-period` data type (Interval). One record per period the user was not moving while wearing the device.
+    topic: push_googlehealth_sedentary_period
+    value_schema: .push.googlehealth.GoogleHealthSedentaryPeriod
+  - doc: The `activity-level` data type (Interval). Activity level (sedentary to very active) sustained over each interval.
+    topic: push_googlehealth_activity_level
+    value_schema: .push.googlehealth.GoogleHealthActivityLevel
   - doc: The `heart-rate` data type (Sample). Instantaneous heart-rate observations in beats per minute.
     topic: push_googlehealth_heart_rate
     value_schema: .push.googlehealth.GoogleHealthHeartRate

--- a/specifications/push/radar-googlehealth-push-1.0.0.yml
+++ b/specifications/push/radar-googlehealth-push-1.0.0.yml
@@ -10,10 +10,10 @@ data:
   - doc: The `floors` data type (Interval). Elevation gained, in floors, per device-reported interval.
     topic: push_googlehealth_floors
     value_schema: .push.googlehealth.GoogleHealthFloors
-  - doc: The `sedentary-period` data type (Interval). One record per period the user was not moving while wearing the device.
+  - doc: The `sedentary-period` data type (Interval) per period the user was not moving while wearing the device.
     topic: push_googlehealth_sedentary_period
     value_schema: .push.googlehealth.GoogleHealthSedentaryPeriod
-  - doc: The `activity-level` data type (Interval). Activity level (sedentary to very active) sustained over each interval.
+  - doc: The `activity-level` data type (Interval). Activity level (sedentary to very active) sustained over each interval, one minute long in practice.
     topic: push_googlehealth_activity_level
     value_schema: .push.googlehealth.GoogleHealthActivityLevel
   - doc: The `heart-rate` data type (Sample). Instantaneous heart-rate observations in beats per minute.


### PR DESCRIPTION
This PR adds schemas and specifications for the new Google Health data types: Floor, ActivityLevel, and SedentaryPeriod.