### PR TITLE
fix: expose streams and push source types via API

### DIFF
--- a/java-sdk/radar-catalog-server/src/main/java/org/radarbase/schema/service/SourceCatalogueService.kt
+++ b/java-sdk/radar-catalog-server/src/main/java/org/radarbase/schema/service/SourceCatalogueService.kt
@@ -40,6 +40,18 @@ class SourceCatalogueService(
     val connectorSources: SourceTypeResponse
         get() = SourceTypeResponse(connectorSources = sourceCatalogue.connectorSources)
 
+    /** Get all stream sources from the source catalogue.  */
+    @get:Path("/stream")
+    @get:GET
+    val streamSources: SourceTypeResponse
+        get() = SourceTypeResponse(streamSources = sourceCatalogue.streamGroups)
+
+    /** Get all push sources from the source catalogue.  */
+    @get:Path("/push")
+    @get:GET
+    val pushSources: SourceTypeResponse
+        get() = SourceTypeResponse(pushSources = sourceCatalogue.pushSources)
+
     /** Get all sources from the source catalogue.  */
     @get:GET
     val allSourceTypes: SourceTypeResponse
@@ -48,5 +60,7 @@ class SourceCatalogueService(
             activeSources = sourceCatalogue.activeSources,
             monitorSources = sourceCatalogue.monitorSources,
             connectorSources = sourceCatalogue.connectorSources,
+            streamSources = sourceCatalogue.streamGroups,
+            pushSources = sourceCatalogue.pushSources,
         )
 }

--- a/java-sdk/radar-catalog-server/src/main/java/org/radarbase/schema/service/SourceTypeResponse.kt
+++ b/java-sdk/radar-catalog-server/src/main/java/org/radarbase/schema/service/SourceTypeResponse.kt
@@ -5,6 +5,8 @@ import org.radarbase.schema.specification.active.ActiveSource
 import org.radarbase.schema.specification.connector.ConnectorSource
 import org.radarbase.schema.specification.monitor.MonitorSource
 import org.radarbase.schema.specification.passive.PassiveSource
+import org.radarbase.schema.specification.push.PushSource
+import org.radarbase.schema.specification.stream.StreamGroup
 
 /** Response with source types.  */
 class SourceTypeResponse(
@@ -16,4 +18,8 @@ class SourceTypeResponse(
     val monitorSources: List<MonitorSource>? = null,
     @JsonProperty("connector-source-types")
     val connectorSources: List<ConnectorSource>? = null,
+    @JsonProperty("stream-source-types")
+    val streamSources: List<StreamGroup>? = null,
+    @JsonProperty("push-source-types")
+    val pushSources: List<PushSource>? = null,
 )


### PR DESCRIPTION
# Problem
S3-connector does not sync push_googlehealth_x topics to intermediate storage.

# Analysis
S3-connector gets topics via the `/source-types` endpoint of catalog server. Catalog server does not expose the new _push_ datatypes via this endpoint.

# Solution
This PR will expose the new source types via the `/source-types` endpoint. 